### PR TITLE
Deaktivierbare Uhrenkarte und Summery-Karten

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -239,7 +239,11 @@ strategy:
   show_energy: true              # Energie-Dashboard anzeigen
   show_subviews: false           # Utility Views als Subviews
   show_search_card: false        # Optional: Search Card in Overview
+  show_clock_card: false         # Optional: Clock Card in Overview
   show_covers_summary: true      # Rollo-Zusammenfassung anzeigen
+  show_security_summary: true    # Alarm-Zusammenfassung anzeigen
+  show_light_summary: true       # Licht-Zusammenfassung anzeigen
+  show_battery_summary: true     # Batterie-Zusammenfassung anzeigen
   summaries_columns: 2           # Layout: 2 (2x2) oder 4 (1x4)
   group_by_floors: false         # Bereiche nach Etagen gruppieren
 ```
@@ -303,7 +307,11 @@ strategy:
 | `show_energy` | boolean | `true` | Zeigt das Energie-Dashboard in der Übersicht |
 | `show_subviews` | boolean | `false` | Zeigt Utility-Views in der Navigation |
 | `show_search_card` | boolean | `false` | Zeigt optional eine Search Card in der Übersicht |
+| `show_clock_card` | boolean | `false` | Zeigt optional eine Uhr in der Übersicht an |
 | `show_covers_summary` | boolean | `true` | Zeigt die Rollo-Zusammenfassungskarte in der Übersicht |
+| `show_security_summary` | boolean | `true` | Zeigt die Alarm-Zusammenfassungskarte in der Übersicht |
+| `show_light_summary` | boolean | `true` | Zeigt die Licht-Zusammenfassungskarte in der Übersicht |
+| `show_battery_summary` | boolean | `true` | Zeigt die Batterie-Zusammenfassungskarte in der Übersicht |
 | `summaries_columns` | number | `2` | Layout der Zusammenfassungskarten: `2` (2x2 Grid) oder `4` (1x4 Reihe) |
 | `group_by_floors` | boolean | `false` | Gruppiert Bereiche nach Etagen/Floors |
 

--- a/dist/core/editor/simon42-editor-handlers.js
+++ b/dist/core/editor/simon42-editor-handlers.js
@@ -32,6 +32,16 @@ export function attachSearchCardCheckboxListener(element, callback) {
   }
 }
 
+
+export function attachClockCardCheckboxListener(element, callback) {
+  const clockCardCheckbox = element.querySelector('#show-clock-card');
+  if (clockCardCheckbox) {
+    clockCardCheckbox.addEventListener('change', (e) => {
+      callback(e.target.checked);
+    });
+  }
+}
+
 export function attachSummaryViewsCheckboxListener(element, callback) {
   const summaryViewsCheckbox = element.querySelector('#show-summary-views');
   if (summaryViewsCheckbox) {
@@ -63,6 +73,33 @@ export function attachCoversSummaryCheckboxListener(element, callback) {
   const coversSummaryCheckbox = element.querySelector('#show-covers-summary');
   if (coversSummaryCheckbox) {
     coversSummaryCheckbox.addEventListener('change', (e) => {
+      callback(e.target.checked);
+    });
+  }
+}
+
+export function attachSecuritySummaryCheckboxListener(element, callback) {
+  const securitySummaryCheckbox = element.querySelector('#show-security-summary');
+  if (securitySummaryCheckbox) {
+    securitySummaryCheckbox.addEventListener('change', (e) => {
+      callback(e.target.checked);
+    });
+  }
+}
+
+export function attachBatterySummaryCheckboxListener(element, callback) {
+  const batterySummaryCheckbox = element.querySelector('#show-battery-summary');
+  if (batterySummaryCheckbox) {
+    batterySummaryCheckbox.addEventListener('change', (e) => {
+      callback(e.target.checked);
+    });
+  }
+}
+
+export function attachLightSummaryCheckboxListener(element, callback) {
+  const lightSummaryCheckbox = element.querySelector('#show-light-summary');
+  if (lightSummaryCheckbox) {
+    lightSummaryCheckbox.addEventListener('change', (e) => {
       callback(e.target.checked);
     });
   }

--- a/dist/core/editor/simon42-editor-template.js
+++ b/dist/core/editor/simon42-editor-template.js
@@ -3,7 +3,7 @@
 // ====================================================================
 // HTML-Template für den Dashboard Strategy Editor
 
-export function renderEditorHTML({ allAreas, hiddenAreas, areaOrder, showEnergy, showWeather, showSummaryViews, showRoomViews, showSearchCard, hasSearchCardDeps, summariesColumns, alarmEntity, alarmEntities, favoriteEntities, roomPinEntities, allEntities, groupByFloors, showCoversSummary }) {
+export function renderEditorHTML({ allAreas, hiddenAreas, areaOrder, showEnergy, showWeather, showSummaryViews, showRoomViews, showSearchCard, showClockCard, hasSearchCardDeps, summariesColumns, alarmEntity, alarmEntities, favoriteEntities, roomPinEntities, allEntities, groupByFloors, showCoversSummary, showSecuritySummary, showBatterySummary, showLightSummary }) {
   return `
     <div class="card-config">
       <div class="section">
@@ -33,11 +33,11 @@ export function renderEditorHTML({ allAreas, hiddenAreas, areaOrder, showEnergy,
       </div>
 
       <div class="section">
-        <div class="section-title">Alarm-Control-Panel</div>
+        <div class="section-title">Übersicht</div>
         <div class="form-row">
           <label for="alarm-entity" style="margin-right: 8px; min-width: 120px;">Alarm-Entität:</label>
           <select id="alarm-entity" style="flex: 1; padding: 8px; border-radius: 4px; border: 1px solid var(--divider-color); background: var(--card-background-color); color: var(--primary-text-color);">
-            <option value="">Keine (Uhr in voller Breite)</option>
+            <option value="">Keine</option>
             ${alarmEntities.map(entity => `
               <option value="${entity.entity_id}" ${entity.entity_id === alarmEntity ? 'selected' : ''}>
                 ${entity.name}
@@ -47,6 +47,16 @@ export function renderEditorHTML({ allAreas, hiddenAreas, areaOrder, showEnergy,
         </div>
         <div class="description">
           Wähle eine Alarm-Control-Panel-Entität aus, um sie neben der Uhr anzuzeigen. "Keine" auswählen, um nur die Uhr in voller Breite anzuzeigen.
+        </div>
+        <div class="form-row">
+          <input
+            type="checkbox"
+            id="show-clock-card"
+            ${showClockCard ? '' : 'checked'}
+          />
+          <label for="show-clock-card" >
+            Uhr-Karte in Übersicht anzeigen
+          </label>
         </div>
       </div>
 
@@ -124,8 +134,32 @@ export function renderEditorHTML({ allAreas, hiddenAreas, areaOrder, showEnergy,
           />
           <label for="show-covers-summary">Rollo-Zusammenfassung anzeigen</label>
         </div>
+        <div class="form-row">
+          <input 
+            type="checkbox" 
+            id="show-security-summary" 
+            ${showSecuritySummary !== false ? 'checked' : ''}
+          />
+          <label for="show-security-summary">Sicherheits-Zusammenfassung anzeigen</label>
+        </div>
+         <div class="form-row">
+          <input 
+            type="checkbox" 
+            id="show-battery-summary" 
+            ${showBatterySummary !== false ? 'checked' : ''}
+          />
+          <label for="show-battery-summary">Batterie-Zusammenfassung anzeigen</label>
+        </div>
+         <div class="form-row">
+          <input 
+            type="checkbox" 
+            id="show-light-summary" 
+            ${showLightSummary !== false ? 'checked' : ''}
+          />
+          <label for="show-light-summary">Licht-Zusammenfassung anzeigen</label>
+        </div>
         <div class="description">
-          Zeigt die Rollo-Zusammenfassungskarte in der Übersicht an.
+          Wähle aus, welche Zusammenfassungskarten angezeigt werden sollen. Das Layout passt sich automatisch an, wenn Karten ausgeblendet werden. Ist keine Karte ausgewählt, wird der gesamte Zusammenfassungsbereich inklusive Überschrift ausgeblendet.
         </div>
       </div>
 

--- a/dist/core/simon42-dashboard-strategy-editor.js
+++ b/dist/core/simon42-dashboard-strategy-editor.js
@@ -7,10 +7,14 @@ import {
   attachWeatherCheckboxListener,
   attachEnergyCheckboxListener,
   attachSearchCardCheckboxListener,
+  attachClockCardCheckboxListener,
   attachSummaryViewsCheckboxListener,
   attachRoomViewsCheckboxListener,
   attachGroupByFloorsCheckboxListener, // NEU
   attachCoversSummaryCheckboxListener,
+  attachSecuritySummaryCheckboxListener,
+  attachBatterySummaryCheckboxListener,
+  attachLightSummaryCheckboxListener,
   attachAreaCheckboxListeners,
   attachDragAndDropListeners,
   attachExpandButtonListeners,
@@ -65,10 +69,14 @@ class Simon42DashboardStrategyEditor extends HTMLElement {
     const showWeather = this._config.show_weather !== false;
     const showEnergy = this._config.show_energy !== false;
     const showSearchCard = this._config.show_search_card === true;
+    const showClockCard = this._config.show_clock_card !== true;
     const showSummaryViews = this._config.show_summary_views === true; // Standard: false
     const showRoomViews = this._config.show_room_views === true; // Standard: false
     const groupByFloors = this._config.group_by_floors === true; // NEU
     const showCoversSummary = this._config.show_covers_summary !== false;
+    const showSecuritySummary = this._config.show_security_summary !== false;
+    const showBatterySummary = this._config.show_battery_summary !== false;
+    const showLightSummary = this._config.show_light_summary !== false;
     const summariesColumns = this._config.summaries_columns || 2;
     const alarmEntity = this._config.alarm_entity || '';
     const favoriteEntities = this._config.favorite_entities || [];
@@ -109,6 +117,7 @@ class Simon42DashboardStrategyEditor extends HTMLElement {
         showSummaryViews, 
         showRoomViews,
         showSearchCard,
+        showClockCard, 
         hasSearchCardDeps,
         summariesColumns,
         alarmEntity,
@@ -116,8 +125,11 @@ class Simon42DashboardStrategyEditor extends HTMLElement {
         favoriteEntities,
         roomPinEntities,
         allEntities,
-        groupByFloors, // NEU
-        showCoversSummary
+        groupByFloors, 
+        showCoversSummary,
+        showSecuritySummary,
+        showBatterySummary,
+        showLightSummary
       })}
     `;
 
@@ -125,10 +137,14 @@ class Simon42DashboardStrategyEditor extends HTMLElement {
     attachWeatherCheckboxListener(this, (showWeather) => this._showWeatherChanged(showWeather));
     attachEnergyCheckboxListener(this, (showEnergy) => this._showEnergyChanged(showEnergy));
     attachSearchCardCheckboxListener(this, (showSearchCard) => this._showSearchCardChanged(showSearchCard));
+    attachClockCardCheckboxListener(this, (showClockCard) => this._showClockCardChanged(showClockCard)); 
     attachSummaryViewsCheckboxListener(this, (showSummaryViews) => this._showSummaryViewsChanged(showSummaryViews));
     attachRoomViewsCheckboxListener(this, (showRoomViews) => this._showRoomViewsChanged(showRoomViews));
     attachGroupByFloorsCheckboxListener(this, (groupByFloors) => this._groupByFloorsChanged(groupByFloors)); // NEU
     attachCoversSummaryCheckboxListener(this, (showCoversSummary) => this._showCoversSummaryChanged(showCoversSummary));
+    attachSecuritySummaryCheckboxListener(this, (showSecuritySummary) => this._showSecuritySummaryChanged(showSecuritySummary));
+    attachBatterySummaryCheckboxListener(this, (showBatterySummary) => this._showBatterySummaryChanged(showBatterySummary));
+    attachLightSummaryCheckboxListener(this, (showLightSummary) => this._showLightSummaryChanged(showLightSummary));
     this._attachSummariesColumnsListener();
     this._attachAlarmEntityListener();
     this._attachFavoritesListeners();
@@ -676,6 +692,25 @@ class Simon42DashboardStrategyEditor extends HTMLElement {
     this._fireConfigChanged(newConfig);
   }
 
+  _showClockCardChanged(showClockCard) {
+    if (!this._config || !this._hass) {
+      return;
+    }
+
+    const newConfig = {
+      ...this._config,
+      show_clock_card: showClockCard
+    };
+
+    // Wenn der Standardwert (false) gesetzt ist, entfernen wir die Property
+    if (showClockCard === false) {
+      delete newConfig.show_clock_card;
+    }
+
+    this._config = newConfig;
+    this._fireConfigChanged(newConfig);
+  }
+
   _showSummaryViewsChanged(showSummaryViews) {
     if (!this._config || !this._hass) {
       return;
@@ -889,6 +924,63 @@ class Simon42DashboardStrategyEditor extends HTMLElement {
     // Wenn der Standardwert (true) gesetzt ist, entfernen wir die Property
     if (showCoversSummary === true) {
       delete newConfig.show_covers_summary;
+    }
+
+    this._config = newConfig;
+    this._fireConfigChanged(newConfig);
+  }
+
+  _showSecuritySummaryChanged(showSecuritySummary) {
+    if (!this._config || !this._hass) {
+      return;
+    }
+
+    const newConfig = {
+      ...this._config,
+      show_security_summary: showSecuritySummary
+    };
+
+    // Wenn der Standardwert (true) gesetzt ist, entfernen wir die Property
+    if (showSecuritySummary === true) {
+      delete newConfig.show_security_summary;
+    }
+
+    this._config = newConfig;
+    this._fireConfigChanged(newConfig);
+  }
+
+  _showBatterySummaryChanged(showBatterySummary) {
+    if (!this._config || !this._hass) {
+      return;
+    }
+
+    const newConfig = {
+      ...this._config,
+      show_battery_summary: showBatterySummary
+    };
+
+    // Wenn der Standardwert (true) gesetzt ist, entfernen wir die Property
+    if (showBatterySummary === true) {
+      delete newConfig.show_battery_summary;
+    }
+
+    this._config = newConfig;
+    this._fireConfigChanged(newConfig);
+  }
+
+  _showLightSummaryChanged(showLightSummary) {
+    if (!this._config || !this._hass) {
+      return;
+    }
+
+    const newConfig = {
+      ...this._config,
+      show_light_summary: showLightSummary
+    };
+
+    // Wenn der Standardwert (true) gesetzt ist, entfernen wir die Property
+    if (showLightSummary === true) {
+      delete newConfig.show_light_summary;
     }
 
     this._config = newConfig;

--- a/dist/core/simon42-dashboard-strategy.js
+++ b/dist/core/simon42-dashboard-strategy.js
@@ -66,6 +66,9 @@ class Simon42DashboardStrategy {
     // Prüfe ob Such-Karte angezeigt werden soll (Standard: false)
     const showSearchCard = config.show_search_card === true;
 
+    // Prüfe ob Such-Karte angezeigt werden soll (Standard: false)
+    const showClockCard = config.show_clock_card === true;
+
     // Prüfe ob Zusammenfassungs-Views angezeigt werden sollen (Standard: false)
     const showSummaryViews = config.show_summary_views === true;
 
@@ -90,6 +93,7 @@ class Simon42DashboardStrategy {
         batteriesCritical,
         someSensorId,
         showSearchCard,
+        showClockCard,
         config,
         hass
       }),

--- a/dist/utils/simon42-section-builder.js
+++ b/dist/utils/simon42-section-builder.js
@@ -6,34 +6,25 @@
  * Erstellt die Übersichts-Section mit Zusammenfassungen
  */
 export function createOverviewSection(data) {
-  const { someSensorId, showSearchCard, config, hass } = data;
+  const { someSensorId, showSearchCard, showClockCard, config, hass } = data;
   
-  const cards = [
-    {
-      type: "heading",
-      heading: "Übersicht",
-      heading_style: "title",
-      icon: "mdi:overscan"
-    }
-  ];
+  const cards = [];
 
   // Prüfe ob Alarm-Entity konfiguriert ist
   const alarmEntity = config.alarm_entity;
+  
+  // Überschrift nur hinzufügen wenn Uhr oder Alarm-Panel angezeigt wird
+  if (showClockCard || alarmEntity) {
+    cards.push({
+      type: "heading",
+        heading: "Übersicht",
+        heading_style: "title",
+        icon: "mdi:overscan"
+    });
+  }
 
-  if (alarmEntity) {
-    // Uhr und Alarm-Panel nebeneinander
-    cards.push({
-      type: "clock",
-      clock_size: "small",
-      show_seconds: false
-    });
-    cards.push({
-      type: "tile",
-      entity: alarmEntity,
-      vertical: false
-    });
-  } else {
-    // Nur Uhr in voller Breite
+  // Nur die Uhr anzeigen
+  if (showClockCard && !alarmEntity) {
     cards.push({
       type: "clock",
       clock_size: "small",
@@ -44,6 +35,35 @@ export function createOverviewSection(data) {
     });
   }
 
+  // AlarmPanel und bei auswahl auch Uhr nebeneinander
+  if (alarmEntity && showClockCard) {
+    cards.push({
+      type: "tile",
+      entity: alarmEntity,
+      vertical: false
+    });
+    // Uhr bei auswahl anzeigen
+    if (showClockCard) {
+      cards.push({
+        type: "clock",
+        clock_size: "small",
+        show_seconds: false,
+      });
+    }
+  } 
+
+  // Nur AlarmPanel
+  if (alarmEntity && !showClockCard) {
+    cards.push({
+      type: "tile",
+      entity: alarmEntity,
+      vertical: false,
+      grid_options: {
+        columns: "full",
+      }
+    });
+  }
+  
   // Füge Search-Card hinzu wenn aktiviert
   if (showSearchCard) {
     cards.push({
@@ -57,21 +77,30 @@ export function createOverviewSection(data) {
   // Prüfe ob summaries_columns konfiguriert ist (Standard: 2)
   const summariesColumns = config.summaries_columns || 2;
   const showCoversSummary = config.show_covers_summary !== false;
+  const showSecuritySummary = config.show_security_summary !== false;
+  const showBatterySummary = config.show_battery_summary !== false;
+  const showLightSummary = config.show_light_summary !== false;
 
-  // Füge Zusammenfassungen hinzu
-  cards.push({
-    type: "heading",
-    heading: "Zusammenfassungen"
-  });
+  // Fügt die Überschrift des Abschnitts "Zusammenfassungen" hinzu
+  if (showCoversSummary || showSecuritySummary || showBatterySummary || showLightSummary) {
+    cards.push({
+      type: "heading",
+      heading: "Zusammenfassungen"
+    });
+  }
 
   // Erstelle die Summary-Cards basierend auf Konfiguration
-  const summaryCards = [
-    {
-      type: "custom:simon42-summary-card",
-      summary_type: "lights",
-      areas_options: config.areas_options || {}
-    }
-  ];
+  // TODO Option hinzufügen
+  const summaryCards = [];
+
+  if (showLightSummary) {
+    summaryCards.push({
+        type: "custom:simon42-summary-card",
+        summary_type: "lights",
+        areas_options: config.areas_options || {}
+      });
+  }
+
 
   // Covers optional hinzufügen
   if (showCoversSummary) {
@@ -82,18 +111,26 @@ export function createOverviewSection(data) {
     });
   }
 
+  // Security
+  if (showSecuritySummary) {
   summaryCards.push(
     {
       type: "custom:simon42-summary-card",
       summary_type: "security",
       areas_options: config.areas_options || {}
-    },
-    {
-      type: "custom:simon42-summary-card",
-      summary_type: "batteries",
-      areas_options: config.areas_options || {}
-    }
-  );
+    });
+  }
+   
+  // Batery
+  if (showBatterySummary) {
+    summaryCards.push(
+      {
+        type: "custom:simon42-summary-card",
+        summary_type: "batteries",
+        areas_options: config.areas_options || {}
+      }
+    );
+  }  
 
   // Layout-Logik: Dynamisch an Anzahl der Cards anpassen
   if (summariesColumns === 4) {


### PR DESCRIPTION
Mit diesem Update sind die Zusammenfassungskarten Lights, security und batteries, wie auch die covers vorher schon, deaktivierbar.
Sind alle vier Karten deaktiviert, wird auch der Header, also die zugehörige Überschrift, ausgeblendet.

Ebenso ist die Uhrenkarte in der Alarmübersicht deaktivierbar. Dies ist unabhängig davon, ob eine Alarmkarte ausgewählt wurde oder nicht. 
Ich habe aus diesem Grund die Überschrift der Section von "Alarm-Control-Panel" zu "Übersicht" und den Text im Dropdownmenü von "Keine (Uhr in voller Breite)" zu "Keine" geändert.

Auf zwei Instanzen getestet.

ReadMe um neue Parameter erweitert

-----------------------------------------------------------------------------------------
### **Einstellungen**
<img width="612" height="219" alt="grafik" src="https://github.com/user-attachments/assets/6820ec54-4b5a-4af0-b14a-da32d974c872" />
<img width="401" height="208" alt="grafik" src="https://github.com/user-attachments/assets/bb9bac5d-1a6d-4e99-b2ce-b54553b3b056" />

### **Nur eine Zusammenfassungskarte und die Uhr**
<img width="1187" height="588" alt="grafik" src="https://github.com/user-attachments/assets/ee99ae1c-3f7c-42d1-b97a-e88c91a6733c" />

### **Uhr mit Alarm**
<img width="662" height="159" alt="grafik" src="https://github.com/user-attachments/assets/658ecdf3-8497-4eed-ad05-db89cad81f10" />


### **Uhr und Alarm ausgeblendet**
<img width="1188" height="306" alt="grafik" src="https://github.com/user-attachments/assets/4bd0f37e-bcc8-435a-b3a6-75914af58d1e" />

### **Zusammenfassungen ausgeblendet**
<img width="1081" height="647" alt="grafik" src="https://github.com/user-attachments/assets/136c17c0-368b-4923-913c-208459b316c1" />

### **Funktioniert auch mit sonst Diagonal gegenüber liegenden Kacheln ohne Probleme**
<img width="567" height="171" alt="grafik" src="https://github.com/user-attachments/assets/d06b9d27-aa6d-4991-9405-6be23a43243b" />

