### PR TITLE
Filter Batterien nach Einheit

### DIFF
--- a/dist/cards/simon42-summary-card.js
+++ b/dist/cards/simon42-summary-card.js
@@ -176,6 +176,10 @@ class Simon42SummaryCard extends HTMLElement {
               state.attributes?.device_class !== 'battery') {
             return false;
           }
+
+          if (state.attributes?.unit_of_measurement !== '%') {
+            return false;
+          }
           
           // Exclude-Checks
           if (this._excludeLabelsSet.has(id)) return false;

--- a/dist/views/simon42-view-batteries.js
+++ b/dist/views/simon42-view-batteries.js
@@ -36,8 +36,10 @@ class Simon42ViewBatteriesStrategy {
         if (!state) return false;
         
         // 1. Battery-Check zuerst (String-includes ist schnell)
-        const isBattery = entityId.includes('battery') || 
-                         state.attributes?.device_class === 'battery';
+        const isBattery = (entityId.includes('battery') || 
+                         state.attributes?.device_class === 'battery') &&
+                         state.attributes?.unit_of_measurement === '%';
+
         if (!isBattery) return false;
         
         // 2. Registry-Check - DIREKT aus hass.entities (O(1) Lookup)


### PR DESCRIPTION
Ich habe einen Batteriespeicher in HA integriert, welcher in dem Dashboard als Batterie aufgeführt wird und Werte wie 20kwh werden dann als kritisch dargestellt. Dieser Fix soll nur Batterien mit der Einheit "%" einbeziehen, sowohl im view, wie auch in der Übersicht.