### PR TITLE
Homeassistant Sortierung fuer Bereiche

### DIFF
--- a/dist/core/editor/simon42-editor-handlers.js
+++ b/dist/core/editor/simon42-editor-handlers.js
@@ -59,6 +59,15 @@ export function attachGroupByFloorsCheckboxListener(element, callback) {
   }
 }
 
+export function attachAreaSortingDefaultCheckboxListener(element, callback) {
+  const areaSortingDefaultCheckbox = element.querySelector('#area-sorting-default');
+  if (areaSortingDefaultCheckbox) {
+    areaSortingDefaultCheckbox.addEventListener('change', (e) => {
+      callback(e.target.checked);
+    });
+  }
+}
+
 export function attachCoversSummaryCheckboxListener(element, callback) {
   const coversSummaryCheckbox = element.querySelector('#show-covers-summary');
   if (coversSummaryCheckbox) {

--- a/dist/core/editor/simon42-editor-template.js
+++ b/dist/core/editor/simon42-editor-template.js
@@ -3,7 +3,7 @@
 // ====================================================================
 // HTML-Template für den Dashboard Strategy Editor
 
-export function renderEditorHTML({ allAreas, hiddenAreas, areaOrder, showEnergy, showWeather, showSummaryViews, showRoomViews, showSearchCard, hasSearchCardDeps, summariesColumns, alarmEntity, alarmEntities, favoriteEntities, roomPinEntities, allEntities, groupByFloors, showCoversSummary }) {
+export function renderEditorHTML({ allAreas, hiddenAreas, areaOrder, showEnergy, showWeather, showSummaryViews, showRoomViews, showSearchCard, hasSearchCardDeps, summariesColumns, alarmEntity, alarmEntities, favoriteEntities, roomPinEntities, allEntities, groupByFloors, showCoversSummary, areaSortingDefault}) {
   return `
     <div class="card-config">
       <div class="section">
@@ -201,6 +201,14 @@ export function renderEditorHTML({ allAreas, hiddenAreas, areaOrder, showEnergy,
         <div class="section-title">Bereiche</div>
         <div class="description" style="margin-left: 0; margin-bottom: 12px;">
           Wähle aus, welche Bereiche im Dashboard angezeigt werden sollen und in welcher Reihenfolge. Klappe Bereiche auf, um einzelne Entitäten zu verwalten.
+        </div>
+        <div class="form-row">
+          <input 
+            type="checkbox" 
+            id="area-sorting-default" 
+            ${areaSortingDefault ? "checked" : ""}
+          />
+          <label for="area-sorting-default">Sortierung der Bereiche von Homeassistant verwenden</label>
         </div>
         <div class="area-list" id="area-list">
           ${renderAreaItems(allAreas, hiddenAreas, areaOrder)}

--- a/dist/core/simon42-dashboard-strategy-editor.js
+++ b/dist/core/simon42-dashboard-strategy-editor.js
@@ -10,6 +10,7 @@ import {
   attachSummaryViewsCheckboxListener,
   attachRoomViewsCheckboxListener,
   attachGroupByFloorsCheckboxListener, // NEU
+  attachAreaSortingDefaultCheckboxListener,
   attachCoversSummaryCheckboxListener,
   attachAreaCheckboxListeners,
   attachDragAndDropListeners,
@@ -68,6 +69,7 @@ class Simon42DashboardStrategyEditor extends HTMLElement {
     const showSummaryViews = this._config.show_summary_views === true; // Standard: false
     const showRoomViews = this._config.show_room_views === true; // Standard: false
     const groupByFloors = this._config.group_by_floors === true; // NEU
+    const areaSortingDefault = this._config.area_sorting_default === false;
     const showCoversSummary = this._config.show_covers_summary !== false;
     const summariesColumns = this._config.summaries_columns || 2;
     const alarmEntity = this._config.alarm_entity || '';
@@ -117,7 +119,8 @@ class Simon42DashboardStrategyEditor extends HTMLElement {
         roomPinEntities,
         allEntities,
         groupByFloors, // NEU
-        showCoversSummary
+        showCoversSummary,
+        areaSortingDefault
       })}
     `;
 
@@ -128,6 +131,7 @@ class Simon42DashboardStrategyEditor extends HTMLElement {
     attachSummaryViewsCheckboxListener(this, (showSummaryViews) => this._showSummaryViewsChanged(showSummaryViews));
     attachRoomViewsCheckboxListener(this, (showRoomViews) => this._showRoomViewsChanged(showRoomViews));
     attachGroupByFloorsCheckboxListener(this, (groupByFloors) => this._groupByFloorsChanged(groupByFloors)); // NEU
+    attachAreaSortingDefaultCheckboxListener(this, (areaSortingDefault) => this._areaSortingDefaultChanged(areaSortingDefault));
     attachCoversSummaryCheckboxListener(this, (showCoversSummary) => this._showCoversSummaryChanged(showCoversSummary));
     this._attachSummariesColumnsListener();
     this._attachAlarmEntityListener();

--- a/dist/core/simon42-dashboard-strategy.js
+++ b/dist/core/simon42-dashboard-strategy.js
@@ -43,7 +43,7 @@ class Simon42DashboardStrategy {
       .map(e => e.entity_id);
 
     // Filtere und sortiere Areale basierend auf Config
-    const visibleAreas = getVisibleAreas(areas, config.areas_display);
+    const visibleAreas = getVisibleAreas(areas, config.areas_display, config.area_sorting_default);
 
     // Sammle alle benötigten Daten (übergebe config für areas_options Filterung)
     const persons = collectPersons(hass, excludeLabels, config);
@@ -74,6 +74,9 @@ class Simon42DashboardStrategy {
 
     // Prüfe ob Bereiche nach Etagen gruppiert werden sollen (Standard: false)
     const groupByFloors = config.group_by_floors === true;
+
+    // Prüfe ob Bereiche die Homassistant Sortierung verwenden sollen (Standard: false)
+    const areaSortingDefault = config.area_sorting_default === true;
 
     // Erstelle Bereiche-Section(s)
     const areasSections = createAreasSection(visibleAreas, groupByFloors, hass);

--- a/dist/utils/simon42-helpers.js
+++ b/dist/utils/simon42-helpers.js
@@ -11,13 +11,17 @@
  * @param {Object} displayConfig - Anzeige-Konfiguration (hidden, order)
  * @returns {Array} Gefilterte und sortierte Bereiche
  */
-export function getVisibleAreas(areas, displayConfig) {
+export function getVisibleAreas(areas, displayConfig, areaSortingDefault = false) {
   const hiddenAreas = displayConfig?.hidden || [];
   const orderConfig = displayConfig?.order || [];
   
   // Filtere versteckte Areale
   let visibleAreas = areas.filter(area => !hiddenAreas.includes(area.area_id));
   
+  if (areaSortingDefault) {
+    return visibleAreas
+  }
+
   // Sortiere nach Konfiguration
   if (orderConfig.length > 0) {
     visibleAreas.sort((a, b) => {


### PR DESCRIPTION
Die `areas` werden aktuell hier https://github.com/TheRealSimon42/simon42-dashboard-strategy/blob/main/dist/utils/simon42-helpers.js#L14 verarbeitet und vorsortiert. leider wird die Homeassistant-eigene Sortierung nicht respektiert und entsprechend überschrieben.

Das Verwenden der "Homeassistant-eigenen Sortierung" könnte man eventuell per Konfiguration ermöglichen.

<img width="1321" height="524" alt="Image" src="https://github.com/user-attachments/assets/7c4db654-3b81-4902-8030-6c1b80d768a4" />

Der Screenshot zeigt recht die originale  "Homeassistant-eigene Sortierung", ab Zeile 22 wird dann sortiert aber es gibt keinen early return etc für die originale Variante.

--- 

Dieser PR fügt den genannten early return ein wenn das setting gesetzt ist. Leider habe ich es nicht hinbekommen das Setting in meinem DEV environment anzuzeigen. Es ist aber alles blind vorbereitet.