### PR TITLE
fix: door/window badge names + battery sort by level

### DIFF
--- a/src/views/BatteriesViewStrategy.ts
+++ b/src/views/BatteriesViewStrategy.ts
@@ -86,6 +86,18 @@ class Simon42ViewBatteriesStrategy extends HTMLElement {
       else good.push(entityId);
     }
 
+    // Sort each group by battery level (lowest first)
+    const sortByLevel = (a: string, b: string): number => {
+      const valA = parseFloat(hass.states[a]?.state);
+      const valB = parseFloat(hass.states[b]?.state);
+      if (isNaN(valA)) return -1;
+      if (isNaN(valB)) return 1;
+      return valA - valB;
+    };
+    critical.sort(sortByLevel);
+    low.sort(sortByLevel);
+    good.sort(sortByLevel);
+
     const sections: LovelaceSectionConfig[] = [];
 
     if (critical.length > 0) {

--- a/src/views/RoomViewStrategy.ts
+++ b/src/views/RoomViewStrategy.ts
@@ -269,8 +269,8 @@ class Simon42ViewRoomStrategy extends HTMLElement {
     if (sensorEntities.motion[0]) badges.push(badgeConfig(sensorEntities.motion[0], 'yellow'));
     if (sensorEntities.occupancy[0]) badges.push(badgeConfig(sensorEntities.occupancy[0], 'cyan'));
     if (sensorEntities.absolute_humidity[0]) badges.push(badgeConfig(sensorEntities.absolute_humidity[0], 'blue'));
-    for (const id of sensorEntities.window) badges.push(badgeConfig(id, 'teal'));
-    for (const id of sensorEntities.door) badges.push(badgeConfig(id, 'teal'));
+    for (const id of sensorEntities.window) badges.push({ ...badgeConfig(id, 'teal'), show_name: true });
+    for (const id of sensorEntities.door) badges.push({ ...badgeConfig(id, 'teal'), show_name: true });
     if (sensorEntities.smoke[0]) badges.push(badgeConfig(sensorEntities.smoke[0], 'red'));
     if (sensorEntities.gas[0]) badges.push(badgeConfig(sensorEntities.gas[0], 'red'));
 


### PR DESCRIPTION
## Summary
- Door and window contact badges in room views now show the entity name (Closes #124)
- Battery view sorts entities by charge level within each group, lowest first (Closes #101)

## Test plan
- [x] Room view: door/window badges show entity name
- [x] Battery view: entities sorted by charge level (lowest first)
- [x] No regressions in other views

🤖 Generated with [Claude Code](https://claude.com/claude-code)