### PR TITLE
chore: pin GitHub Action versions to SHAs + add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+# ============================================================================
+# Dependabot — GitHub Actions version updates
+# ============================================================================
+# Watches every `uses:` in .github/workflows/ and opens a PR whenever an
+# upstream action publishes a newer release. Required for sustainable
+# SHA-pinning: dependabot updates the SHA + comment (e.g. `# v4`) together
+# so the workflow stays both pinned and current.
+#
+# To extend coverage: add `package-ecosystem: npm` for dependency updates,
+# or schedule changes to `daily` / `weekly` per maintainer preference.
+# ============================================================================
+
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore(deps)

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
         with:
           days-before-stale: 35
           days-before-close: 7

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,7 +14,7 @@ jobs:
     name: HACS Validation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - uses: hacs/action@dcb30e72781db3f207d5236b861172774ab0b485 # main @ 2026-05-18
         with:
           category: plugin

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,7 +14,7 @@ jobs:
     name: HACS Validation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: hacs/action@main
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: hacs/action@dcb30e72781db3f207d5236b861172774ab0b485 # main @ 2026-05-18
         with:
           category: plugin


### PR DESCRIPTION
## Summary

Supply-chain hardening for the workflows currently on `main`. Pins every `uses:` to an immutable commit SHA so tag refs (`v5`, `@main`) can't be force-moved to swap the code that runs on every PR. Pairs with the maintainer security-hardening checklist tracked in #229.

## Changes

| File | Action | Before | After |
|---|---|---|---|
| `.github/workflows/validate.yml` | `actions/checkout` | `@v4` | `@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5` |
| `.github/workflows/validate.yml` | `hacs/action` | `@main` | `@dcb30e72781db3f207d5236b861172774ab0b485 # main @ 2026-05-18` |
| `.github/workflows/stale.yml` | `actions/stale` | `@v9` | `@5bef64f19d7facfb25b37b414482c7164d639639 # v9` |
| `.github/dependabot.yml` | NEW | — | weekly `github-actions` updates |

The trailing `# vN` comment preserves the human-readable version. Dependabot updates the SHA + comment together when upstream cuts a new release.

`actions/checkout` jumped straight to **v5** (Node 24-based) — GitHub deprecated Node 20 actions effective June 2026, so pinning to v4 would have shipped already-deprecated infra.

## Why

OWASP and SLSA both recommend SHA-pinning for any third-party Action. Tag references are mutable — an attacker who compromises an action maintainer's account (or a benign mistake from the maintainer) can repoint `v5` to malicious code that then runs with this repo's `GITHUB_TOKEN` and secrets. Pinning removes this class of risk; Dependabot keeps it sustainable.

For `hacs/action@main` specifically — `main` is the worst case (no semver, always tracks HEAD). Pinning to today's HEAD is a strict improvement; Dependabot won't auto-update branch refs but will surface major-version changes if the upstream switches to tags.

## Test plan

- [x] **YAML syntax valid** — `validate.yml`, `stale.yml`, `dependabot.yml` all parse cleanly with `yaml.safe_load`
- [x] **Node 24-ready** — all `actions/checkout` pins use v5 SHAs
- [x] **Workflow runs end-to-end on a fork carrying these same pins** — `workflow_dispatch` on `TheDave94/simon42-dashboard-strategy@main` completed in ~45s with `HACS Validation` ✓ and `Unit tests` ✓ (run [26033043107](https://github.com/TheDave94/simon42-dashboard-strategy/actions/runs/26033043107))
- [ ] **Dependabot opens future PRs against `.github/workflows/`** — observational over coming weeks once merged

## Related

- #229 — security-hardening checklist for the maintainer (signed commits, branch protection, etc.)
- #226 — test scaffold PR; ships its newly-introduced `setup-node` action already SHA-pinned to v5 (Node 24-ready out of the gate)

---
_AI-drafted under human supervision by @TheDave94. Tested live on Home Assistant — fully when the relevant hardware is available, otherwise only along the code paths that don't require an actual sensor of that type._