### PR TITLE
feat(covers): per-group heading icons; awnings default to storefront (closes #144)

### DIFF
--- a/src/cards/CoversGroupCard.ts
+++ b/src/cards/CoversGroupCard.ts
@@ -24,6 +24,9 @@ interface CoversGroupConfig {
   heading_partial?: string;
   batch_open_text?: string;
   batch_close_text?: string;
+  icon_open?: string;
+  icon_closed?: string;
+  icon_partial?: string;
 }
 
 // Pre-compiled RegExps for cover type name stripping
@@ -205,7 +208,7 @@ class Simon42CoversGroupCard extends LitElement {
       return {
         type: 'heading',
         heading: `${headingLabel} (${covers.length})`,
-        icon: 'mdi:blinds-horizontal',
+        icon: this._config.icon_partial || 'mdi:blinds-horizontal',
         badges: [
           {
             type: 'button',
@@ -235,10 +238,14 @@ class Simon42CoversGroupCard extends LitElement {
     const headingLabel = isOpen
       ? (this._config.heading_open || localize('covers.open'))
       : (this._config.heading_closed || localize('covers.closed'));
+    const defaultIcon = isOpen ? 'mdi:blinds-horizontal' : 'mdi:blinds';
+    const headingIcon = isOpen
+      ? (this._config.icon_open || defaultIcon)
+      : (this._config.icon_closed || defaultIcon);
     return {
       type: 'heading',
       heading: `${headingLabel} (${covers.length})`,
-      icon: isOpen ? 'mdi:blinds-horizontal' : 'mdi:blinds',
+      icon: headingIcon,
       badges: [
         {
           type: 'button',

--- a/src/views/CoversViewStrategy.ts
+++ b/src/views/CoversViewStrategy.ts
@@ -57,6 +57,9 @@ class Simon42ViewCoversStrategy extends HTMLElement {
         heading_partial: localize('covers.awnings_partial'),
         batch_open_text: localize('covers.awnings_open_all'),
         batch_close_text: localize('covers.awnings_close_all'),
+        icon_open: strategyConfig.awning_icon_open || 'mdi:storefront-outline',
+        icon_closed: strategyConfig.awning_icon_closed || 'mdi:storefront',
+        icon_partial: strategyConfig.awning_icon_partial || 'mdi:storefront-outline',
       };
 
       cards.push({


### PR DESCRIPTION
## Summary

Closes #144 — the awnings group currently shows `mdi:blinds-horizontal` / `mdi:blinds`, which doesn't visually match awnings. This PR:

- Adds optional `icon_open` / `icon_closed` / `icon_partial` to `CoversGroupCard`
- `CoversViewStrategy` passes `mdi:storefront-outline` / `mdi:storefront` for the awning group by default
- Other cover groups (blind/curtain/shade/shutter, windows) are unchanged

## Configurability

Sensible default for awnings, but YAML-overridable via the strategy config:

```yaml
strategy:
  type: custom:simon42-dashboard
  awning_icon_open: mdi:weather-sunny
  awning_icon_closed: mdi:weather-night
  awning_icon_partial: mdi:weather-partly-cloudy
```

If a user has no awning covers, the whole group is already skipped by the existing `hasAwnings` check — no behavioural change for them.

## Test plan

- [x] TypeScript clean (`tsc --noEmit`)
- [x] Dashboard with `cover` entities of `device_class: awning` shows the new icon
- [x] Dashboards without awnings render unchanged
- [x] YAML override (`awning_icon_open: ...`) is honoured

---
_AI-drafted under human supervision by @TheDave94. Tested live on Home Assistant — fully when the relevant hardware is available, otherwise only along the code paths that don't require an actual sensor of that type._