### PR TITLE
feat(covers): group covers by floors (closes #109)

### DIFF
--- a/src/cards/CoversGroupCard.ts
+++ b/src/cards/CoversGroupCard.ts
@@ -9,6 +9,11 @@ import { Registry } from '../Registry';
 import { trackHassUpdate } from '../utils/debug';
 import { localize } from '../utils/localize';
 
+interface LovelaceCardElement extends HTMLElement {
+  hass?: HomeAssistant;
+  setConfig(config: Record<string, unknown>): void;
+}
+
 declare global {
   interface Window {
     customCards?: Array<{ type: string; name: string; description: string }>;
@@ -74,7 +79,7 @@ class Simon42CoversGroupCard extends LitElement {
   // Reusable card pool
   private _tileCards: Map<string, any> = new Map();
   private _headingCard: any = null;
-  private _floorHeadingCards: Map<string, any> = new Map();
+  private _floorHeadingCards: Map<string, LovelaceCardElement> = new Map();
 
   static styles = css`
     :host {
@@ -239,6 +244,7 @@ class Simon42CoversGroupCard extends LitElement {
     ];
 
     return sortedKeys.map((floorId) => {
+      // eslint-disable-next-line security/detect-object-injection -- floorId comes from HA floor registry keys
       const floor = floorId ? floors[floorId] : null;
       return {
         floorId,
@@ -267,7 +273,7 @@ class Simon42CoversGroupCard extends LitElement {
     return name.trim() || state.attributes.friendly_name || entityId;
   }
 
-  private _buildHeadingConfig(covers: string[], floorLabel?: string, floorIcon?: string): any {
+  private _buildHeadingConfig(covers: string[], floorLabel?: string, floorIcon?: string): Record<string, unknown> {
     const groupType = this._config.group_type;
     const openText = this._config.batch_open_text || localize('covers.open_all');
     const closeText = this._config.batch_close_text || localize('covers.close_all');
@@ -391,10 +397,10 @@ class Simon42CoversGroupCard extends LitElement {
     `;
   }
 
-  private _getOrCreateFloorHeadingCard(key: string): any {
+  private _getOrCreateFloorHeadingCard(key: string): LovelaceCardElement {
     let card = this._floorHeadingCards.get(key);
     if (card) return card;
-    card = document.createElement('hui-heading-card');
+    card = document.createElement('hui-heading-card') as LovelaceCardElement;
     this._floorHeadingCards.set(key, card);
     return card;
   }

--- a/src/cards/CoversGroupCard.ts
+++ b/src/cards/CoversGroupCard.ts
@@ -4,6 +4,7 @@
 
 import { LitElement, html, css, nothing, type PropertyValues } from 'lit';
 import type { HomeAssistant } from '../types/homeassistant';
+import type { AreaRegistryEntry } from '../types/registries';
 import { Registry } from '../Registry';
 import { trackHassUpdate } from '../utils/debug';
 import { localize } from '../utils/localize';
@@ -24,6 +25,14 @@ interface CoversGroupConfig {
   heading_partial?: string;
   batch_open_text?: string;
   batch_close_text?: string;
+  group_by_floors?: boolean;
+}
+
+interface CoversFloorGroup {
+  floorId: string | null;
+  floorName: string;
+  floorIcon: string;
+  covers: string[];
 }
 
 // Pre-compiled RegExps for cover type name stripping
@@ -59,11 +68,13 @@ class Simon42CoversGroupCard extends LitElement {
   private _config!: CoversGroupConfig;
   private _deviceClasses!: string[];
   private _cachedFilteredIds: Set<string> | null = null;
+  private _cachedAreaForEntity: Map<string, string | null> | null = null;
   private _lastCoversList = '';
 
   // Reusable card pool
   private _tileCards: Map<string, any> = new Map();
   private _headingCard: any = null;
+  private _floorHeadingCards: Map<string, any> = new Map();
 
   static styles = css`
     :host {
@@ -83,6 +94,11 @@ class Simon42CoversGroupCard extends LitElement {
       grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
       gap: 8px;
     }
+    .floor-section {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
   `;
 
   setConfig(config: CoversGroupConfig): void {
@@ -98,6 +114,7 @@ class Simon42CoversGroupCard extends LitElement {
 
     if (!oldHass || oldHass.entities !== this.hass.entities) {
       this._cachedFilteredIds = null;
+      this._cachedAreaForEntity = null;
     }
 
     // Build cache if needed
@@ -181,6 +198,61 @@ class Simon42CoversGroupCard extends LitElement {
     return relevant;
   }
 
+  private _getAreaForEntity(entityId: string): string | null {
+    if (!this._cachedAreaForEntity) this._cachedAreaForEntity = new Map();
+    if (this._cachedAreaForEntity.has(entityId)) {
+      return this._cachedAreaForEntity.get(entityId) ?? null;
+    }
+    const entity = Registry.getEntity(entityId);
+    let areaId: string | null = entity?.area_id ?? null;
+    if (!areaId && entity?.device_id) {
+      const device = Registry.getDevice(entity.device_id);
+      areaId = device?.area_id ?? null;
+    }
+    this._cachedAreaForEntity.set(entityId, areaId);
+    return areaId;
+  }
+
+  private _groupByFloors(covers: string[]): CoversFloorGroup[] {
+    if (!this.hass) return [];
+
+    const areas: AreaRegistryEntry[] = Object.values(this.hass.areas);
+    const areaFloorMap = new Map<string, string | null>();
+    for (const area of areas) {
+      areaFloorMap.set(area.area_id, area.floor_id ?? null);
+    }
+
+    const floorMap = new Map<string | null, string[]>();
+    for (const id of covers) {
+      const areaId = this._getAreaForEntity(id);
+      const floorId = areaId ? (areaFloorMap.get(areaId) ?? null) : null;
+      if (!floorMap.has(floorId)) floorMap.set(floorId, []);
+      floorMap.get(floorId)?.push(id);
+    }
+
+    // HA's floor registry order preserves the user-defined "Reorder areas and floors" sequence
+    const floors = this.hass.floors;
+    const floorOrder = Object.keys(floors);
+    const sortedKeys: (string | null)[] = [
+      ...floorOrder.filter((id) => floorMap.has(id)),
+      ...(floorMap.has(null) ? [null] : []),
+    ];
+
+    return sortedKeys.map((floorId) => {
+      const floor = floorId ? floors[floorId] : null;
+      return {
+        floorId,
+        floorName: floor?.name || localize('lights.floor_other'),
+        floorIcon: floor?.icon || 'mdi:home-outline',
+        covers: floorMap.get(floorId) ?? [],
+      };
+    });
+  }
+
+  private _getFloorDomKey(floorId: string | null): string {
+    return floorId ?? '_none';
+  }
+
   private _stripCoverType(entityId: string): string {
     const state = this.hass?.states[entityId];
     if (!state) return entityId;
@@ -195,17 +267,17 @@ class Simon42CoversGroupCard extends LitElement {
     return name.trim() || state.attributes.friendly_name || entityId;
   }
 
-  private _buildHeadingConfig(covers: string[]): any {
+  private _buildHeadingConfig(covers: string[], floorLabel?: string, floorIcon?: string): any {
     const groupType = this._config.group_type;
     const openText = this._config.batch_open_text || localize('covers.open_all');
     const closeText = this._config.batch_close_text || localize('covers.close_all');
 
     if (groupType === 'partially_open') {
-      const headingLabel = this._config.heading_partial || localize('covers.partially_open');
+      const headingLabel = floorLabel || this._config.heading_partial || localize('covers.partially_open');
       return {
         type: 'heading',
         heading: `${headingLabel} (${covers.length})`,
-        icon: 'mdi:blinds-horizontal',
+        icon: floorIcon || 'mdi:blinds-horizontal',
         badges: [
           {
             type: 'button',
@@ -232,13 +304,13 @@ class Simon42CoversGroupCard extends LitElement {
     }
 
     const isOpen = groupType === 'open';
-    const headingLabel = isOpen
+    const headingLabel = floorLabel || (isOpen
       ? (this._config.heading_open || localize('covers.open'))
-      : (this._config.heading_closed || localize('covers.closed'));
+      : (this._config.heading_closed || localize('covers.closed')));
     return {
       type: 'heading',
       heading: `${headingLabel} (${covers.length})`,
-      icon: isOpen ? 'mdi:blinds-horizontal' : 'mdi:blinds',
+      icon: floorIcon || (isOpen ? 'mdi:blinds-horizontal' : 'mdi:blinds'),
       badges: [
         {
           type: 'button',
@@ -293,12 +365,38 @@ class Simon42CoversGroupCard extends LitElement {
     const covers = this._getRelevantCovers();
     this.hidden = covers.length === 0;
 
+    if (this._config.group_by_floors && covers.length > 0) {
+      const floorGroups = this._groupByFloors(covers);
+      return html`
+        <div class="covers-section">
+          <div id="heading"></div>
+          ${floorGroups.map((group) => {
+            const key = this._getFloorDomKey(group.floorId);
+            return html`
+              <div class="floor-section">
+                <div id=${`floor-heading-${key}`}></div>
+                <div class="cover-grid" id=${`floor-grid-${key}`}></div>
+              </div>
+            `;
+          })}
+        </div>
+      `;
+    }
+
     return html`
       <div class="covers-section">
         <div id="heading"></div>
         <div class="cover-grid" id="grid"></div>
       </div>
     `;
+  }
+
+  private _getOrCreateFloorHeadingCard(key: string): any {
+    let card = this._floorHeadingCards.get(key);
+    if (card) return card;
+    card = document.createElement('hui-heading-card');
+    this._floorHeadingCards.set(key, card);
+    return card;
   }
 
   protected updated(changedProps: PropertyValues): void {
@@ -316,12 +414,74 @@ class Simon42CoversGroupCard extends LitElement {
       const grid = this.shadowRoot?.getElementById('grid');
       if (grid) grid.innerHTML = '';
       this._headingCard = null;
+      this._floorHeadingCards.clear();
       this._tileCards.clear();
       this._lastCoversList = '';
       return;
     }
 
-    // Reconcile heading card
+    if (this._config.group_by_floors) {
+      const floorGroups = this._groupByFloors(covers);
+
+      // Reconcile main heading (total count)
+      const headingSlot = this.shadowRoot?.getElementById('heading');
+      if (headingSlot) {
+        if (!this._headingCard) {
+          this._headingCard = document.createElement('hui-heading-card');
+          headingSlot.appendChild(this._headingCard);
+        }
+        this._headingCard.hass = this.hass;
+        this._headingCard.setConfig(this._buildHeadingConfig(covers));
+      }
+
+      const activeIds = new Set(covers);
+      const activeFloorKeys = new Set<string>();
+
+      // Reconcile per-floor sections
+      for (const group of floorGroups) {
+        const key = this._getFloorDomKey(group.floorId);
+        activeFloorKeys.add(key);
+        const floorHeadingSlot = this.shadowRoot?.getElementById(`floor-heading-${key}`);
+        if (floorHeadingSlot) {
+          const headingCard = this._getOrCreateFloorHeadingCard(key);
+          if (!headingCard.parentNode) floorHeadingSlot.appendChild(headingCard);
+          headingCard.hass = this.hass;
+          headingCard.setConfig(this._buildHeadingConfig(group.covers, group.floorName, group.floorIcon));
+        }
+
+        const grid = this.shadowRoot?.getElementById(`floor-grid-${key}`);
+        if (!grid) continue;
+
+        let prevNode: Node | null = null;
+        for (const entityId of group.covers) {
+          const card = this._getOrCreateTileCard(entityId);
+          const nextSibling = prevNode ? prevNode.nextSibling : grid.firstChild;
+          if (card !== nextSibling) grid.insertBefore(card, nextSibling);
+          prevNode = card;
+        }
+        while (prevNode && prevNode.nextSibling) {
+          grid.removeChild(prevNode.nextSibling);
+        }
+      }
+
+      // Clean up tile cards no longer in any floor
+      for (const [id, card] of this._tileCards) {
+        if (!activeIds.has(id)) {
+          if (card.parentNode) card.parentNode.removeChild(card);
+          this._tileCards.delete(id);
+        }
+      }
+      // Clean up floor heading cards for floors no longer present
+      for (const [k, card] of this._floorHeadingCards) {
+        if (!activeFloorKeys.has(k)) {
+          if (card.parentNode) card.parentNode.removeChild(card);
+          this._floorHeadingCards.delete(k);
+        }
+      }
+      return;
+    }
+
+    // Flat mode (no floor grouping)
     const headingSlot = this.shadowRoot?.getElementById('heading');
     if (headingSlot) {
       if (!this._headingCard) {
@@ -332,13 +492,11 @@ class Simon42CoversGroupCard extends LitElement {
       this._headingCard.setConfig(this._buildHeadingConfig(covers));
     }
 
-    // Reconcile tile cards in grid
     const grid = this.shadowRoot?.getElementById('grid');
     if (!grid) return;
 
     const activeIds = new Set(covers);
 
-    // Remove cards for entities no longer in the list
     for (const [id, card] of this._tileCards) {
       if (!activeIds.has(id)) {
         if (card.parentNode === grid) grid.removeChild(card);
@@ -346,7 +504,6 @@ class Simon42CoversGroupCard extends LitElement {
       }
     }
 
-    // Add/reorder cards to match the desired order
     let prevNode: Node | null = null;
     for (const entityId of covers) {
       const card = this._getOrCreateTileCard(entityId);
@@ -357,7 +514,6 @@ class Simon42CoversGroupCard extends LitElement {
       prevNode = card;
     }
 
-    // Remove trailing stale nodes
     while (prevNode && prevNode.nextSibling) {
       grid.removeChild(prevNode.nextSibling);
     }

--- a/src/editor/StrategyEditor.ts
+++ b/src/editor/StrategyEditor.ts
@@ -1258,6 +1258,7 @@ class Simon42DashboardStrategyEditor extends LitElement {
     const nestedLightGroups = this._config.nested_light_groups === true;
     const showCoversSummary = this._config.show_covers_summary !== false;
     const showPartiallyOpenCovers = this._config.show_partially_open_covers === true;
+    const groupCoversByFloors = this._config.group_covers_by_floors === true;
     const showSecuritySummary = this._config.show_security_summary !== false;
     const showClimateSummary = this._config.show_climate_summary === true;
     const showBatterySummary = this._config.show_battery_summary !== false;
@@ -1301,6 +1302,10 @@ class Simon42DashboardStrategyEditor extends LitElement {
           ${this._renderCheckbox('show-partially-open-covers', localize('editor.show_partially_open_covers'), showPartiallyOpenCovers,
             (checked) => this._toggleChanged('show_partially_open_covers', checked, false))}
           <div class="description">${localize('editor.show_partially_open_covers_desc')}</div>
+
+          ${this._renderCheckbox('group-covers-by-floors', localize('editor.group_covers_by_floors'), groupCoversByFloors,
+            (checked) => this._toggleChanged('group_covers_by_floors', checked, false))}
+          <div class="description">${localize('editor.group_covers_by_floors_desc')}</div>
         </div>
 
         ${this._renderCheckbox('show-security-summary', localize('editor.show_security_summary'), showSecuritySummary,

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -129,6 +129,8 @@
     "show_covers_summary": "Rollo-Zusammenfassung anzeigen",
     "show_partially_open_covers": "Teiloffene Rollos separat anzeigen",
     "show_partially_open_covers_desc": "Zeigt teiloffene Rollos (weder ganz offen noch geschlossen) in einer eigenen Gruppe an.",
+    "group_covers_by_floors": "Rollos nach Etagen gruppieren",
+    "group_covers_by_floors_desc": "Gruppiert die Rollos in der Rollos-Ansicht nach Etagen. Jede Etage erhält einen eigenen Unterabschnitt mit dem Etagennamen als Überschrift. Betrifft die Hauptgruppe; Markisen und Fenster bleiben ungeteilt.",
     "show_security_summary": "Sicherheits-Zusammenfassung anzeigen",
     "show_climate_summary": "Klima-Zusammenfassung anzeigen",
     "show_climate_summary_desc": "Zeigt die Klima-Zusammenfassungskarte in der Übersicht an. Zählt aktive Thermostate und Klimageräte.",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -129,6 +129,8 @@
     "show_covers_summary": "Show cover summary",
     "show_partially_open_covers": "Show partially open covers separately",
     "show_partially_open_covers_desc": "Shows partially open covers (neither fully open nor closed) in a separate group.",
+    "group_covers_by_floors": "Group covers by floors",
+    "group_covers_by_floors_desc": "Groups covers in the covers view by floors. Each floor gets its own subsection with its name as heading. Applies to the main covers group; awnings and windows remain unsplit.",
     "show_security_summary": "Show security summary",
     "show_climate_summary": "Show climate summary",
     "show_climate_summary_desc": "Shows the climate summary card on the overview. Counts active thermostats and climate devices.",

--- a/src/types/strategy.ts
+++ b/src/types/strategy.ts
@@ -30,6 +30,7 @@ export interface Simon42StrategyConfig {
   group_by_floors?: boolean; // default: false
   show_covers_summary?: boolean; // default: true
   show_partially_open_covers?: boolean; // default: false
+  group_covers_by_floors?: boolean; // default: false
   show_clock_card?: boolean; // default: true
   show_light_summary?: boolean; // default: true
   group_lights_by_floors?: boolean; // default: false

--- a/src/views/CoversViewStrategy.ts
+++ b/src/views/CoversViewStrategy.ts
@@ -9,6 +9,7 @@ class Simon42ViewCoversStrategy extends HTMLElement {
   static async generate(config: any, _hass: any): Promise<LovelaceViewConfig> {
     const strategyConfig = config.config || {};
     const showPartiallyOpen = strategyConfig.show_partially_open_covers === true;
+    const groupByFloors = strategyConfig.group_covers_by_floors === true;
 
     // Separate awnings and windows from other covers — they have different semantics
     const allDeviceClasses = config.device_classes || ['awning', 'blind', 'curtain', 'shade', 'shutter', 'window'];
@@ -26,6 +27,7 @@ class Simon42ViewCoversStrategy extends HTMLElement {
         device_classes: coverClasses,
         group_type: 'open',
         show_partially_open: showPartiallyOpen,
+        group_by_floors: groupByFloors,
       },
     ];
 
@@ -36,6 +38,7 @@ class Simon42ViewCoversStrategy extends HTMLElement {
         device_classes: coverClasses,
         group_type: 'partially_open',
         show_partially_open: true,
+        group_by_floors: groupByFloors,
       });
     }
 
@@ -45,6 +48,7 @@ class Simon42ViewCoversStrategy extends HTMLElement {
       device_classes: coverClasses,
       group_type: 'closed',
       show_partially_open: showPartiallyOpen,
+      group_by_floors: groupByFloors,
     });
 
     // Markisen (separate group with own headings/batch actions)


### PR DESCRIPTION
## Summary

Closes #109 — mirrors the existing `group_lights_by_floors` pattern for the covers view. When enabled, the main *Rollos & Vorhänge* group splits into per-floor subsections (each with floor name + floor icon from the HA floor registry). Awnings and Windows groups remain unsplit — they're already semantically separate.

## Configurability

- Editor toggle in the **Summaries** section, indented under *Show partially open covers* (same nesting depth)
- Defaults to `false` — existing dashboards render unchanged
- Yaml key: `group_covers_by_floors: true`

## How it works

`CoversGroupCard` gains a `group_by_floors` mode that uses `_getAreaForEntity` + `_groupByFloors` to partition covers by their area's `floor_id` (falling back to the entity's device area, matching how lights do it). Floors are rendered in the user's HA floor order (the `hass.floors` registry preserves the "Reorder areas and floors" sequence).

## Test plan

- [x] Existing dashboards render identically with the toggle off (default)
- [x] Covers from a 2-floor setup split into 2 subsections when toggled on
- [x] Covers without an area assignment fall into a final "Other" group
- [x] Flat mode → floor mode → flat mode reconciliation cleans up DOM correctly
- [x] Awnings and Windows groups remain unaffected
- [x] TypeScript clean (`tsc --noEmit`)

---
_AI-drafted under human supervision by @TheDave94. Tested live on Home Assistant — fully when the relevant hardware is available, otherwise only along the code paths that don't require an actual sensor of that type._