### PR TITLE
feat(batteries): optional area name on battery tiles (closes #130)

### DIFF
--- a/src/editor/StrategyEditor.ts
+++ b/src/editor/StrategyEditor.ts
@@ -1264,6 +1264,7 @@ class Simon42DashboardStrategyEditor extends LitElement {
     const hideMobileAppBatteries = this._config.hide_mobile_app_batteries === true;
     const batteryCriticalThreshold = this._config.battery_critical_threshold ?? 20;
     const batteryLowThreshold = this._config.battery_low_threshold ?? 50;
+    const showAreaInBatteryView = this._config.show_area_in_battery_view === true;
 
     return html`
       <div class="section">
@@ -1317,6 +1318,10 @@ class Simon42DashboardStrategyEditor extends LitElement {
           ${this._renderCheckbox('hide-mobile-app-batteries', localize('editor.hide_mobile_app_batteries'), hideMobileAppBatteries,
             (checked) => this._toggleChanged('hide_mobile_app_batteries', checked, false))}
           <div class="description">${localize('editor.hide_mobile_app_batteries_desc')}</div>
+
+          ${this._renderCheckbox('show-area-in-battery-view', localize('editor.show_area_in_battery_view'), showAreaInBatteryView,
+            (checked) => this._toggleChanged('show_area_in_battery_view', checked, false))}
+          <div class="description">${localize('editor.show_area_in_battery_view_desc')}</div>
 
           <div style="font-size: 13px; font-weight: 500; color: var(--primary-text-color); margin-top: 12px; margin-bottom: 4px;">
             ${localize('editor.battery_thresholds')}

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -135,6 +135,8 @@
     "show_battery_summary": "Batterie-Zusammenfassung anzeigen",
     "hide_mobile_app_batteries": "Mobile-App-Batterien ausblenden",
     "hide_mobile_app_batteries_desc": "Blendet Batterien von Smartphones, Tablets und Watches (Mobile App) in der Batterie-Übersicht und -Zusammenfassung aus.",
+    "show_area_in_battery_view": "Bereichsname auf Batterie-Kacheln anzeigen",
+    "show_area_in_battery_view_desc": "Stellt den Bereichsnamen vor jeder Batterie-Kachel in der Batterien-Ansicht voran (z.B. „Wohnzimmer • Fenster-Batterie“). Hilfreich, wenn mehrere gleichnamige Kontaktsensoren nur über den Raum unterscheidbar sind.",
     "battery_thresholds": "Batterie-Schwellwerte",
     "battery_critical_below": "Kritisch unter",
     "battery_low_below": "Niedrig unter",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -135,6 +135,8 @@
     "show_battery_summary": "Show battery summary",
     "hide_mobile_app_batteries": "Hide mobile app batteries",
     "hide_mobile_app_batteries_desc": "Hides batteries from smartphones, tablets, and watches (Mobile App) from the battery overview and summary.",
+    "show_area_in_battery_view": "Show area name on battery tiles",
+    "show_area_in_battery_view_desc": "Prepends the area name to each battery tile in the batteries view (e.g. \"Living Room • Window Battery\"). Helps distinguish identically named contact sensors that differ only by room.",
     "battery_thresholds": "Battery thresholds",
     "battery_critical_below": "Critical below",
     "battery_low_below": "Low below",

--- a/src/types/strategy.ts
+++ b/src/types/strategy.ts
@@ -40,6 +40,7 @@ export interface Simon42StrategyConfig {
   hide_mobile_app_batteries?: boolean; // default: false
   battery_critical_threshold?: number; // default: 20
   battery_low_threshold?: number; // default: 50
+  show_area_in_battery_view?: boolean; // default: false
   show_locks_in_rooms?: boolean; // default: false
   show_automations_in_rooms?: boolean; // default: false
   show_scripts_in_rooms?: boolean; // default: false

--- a/src/views/BatteriesViewStrategy.ts
+++ b/src/views/BatteriesViewStrategy.ts
@@ -8,10 +8,23 @@ import { Registry } from '../Registry';
 import { localize } from '../utils/localize';
 import { getBatteryEntities } from '../utils/entity-filter';
 
+function getAreaNameForEntity(entityId: string, hass: HomeAssistant): string | null {
+  const entity = Registry.getEntity(entityId);
+  let areaId: string | null = entity?.area_id ?? null;
+  if (!areaId && entity?.device_id) {
+    const device = Registry.getDevice(entity.device_id);
+    areaId = device?.area_id ?? null;
+  }
+  if (!areaId) return null;
+  return hass.areas?.[areaId]?.name ?? null;
+}
+
 function createBatterySection(
   entities: string[],
   status: 'critical' | 'low' | 'good',
   rangeText: string,
+  hass: HomeAssistant,
+  showArea: boolean,
 ): LovelaceSectionConfig | null {
   if (entities.length === 0) return null;
 
@@ -28,13 +41,23 @@ function createBatterySection(
         }`,
         heading_style: 'title',
       },
-      ...entities.map((e) => ({
-        type: 'tile',
-        entity: e,
-        vertical: false,
-        state_content: ['state', 'last_changed'],
-        color,
-      })),
+      ...entities.map((e) => {
+        const tile: { type: string; [key: string]: unknown } = {
+          type: 'tile',
+          entity: e,
+          vertical: false,
+          state_content: ['state', 'last_changed'],
+          color,
+        };
+        if (showArea) {
+          const areaName = getAreaNameForEntity(e, hass);
+          if (areaName) {
+            const friendly = hass.states[e]?.attributes?.friendly_name as string | undefined;
+            tile.name = friendly ? `${areaName} • ${friendly}` : areaName;
+          }
+        }
+        return tile;
+      }),
     ],
   };
 }
@@ -50,6 +73,7 @@ class Simon42ViewBatteriesStrategy extends HTMLElement {
     const strategyConfig = config.config || {};
     const criticalThreshold = strategyConfig.battery_critical_threshold ?? 20;
     const lowThreshold = strategyConfig.battery_low_threshold ?? 50;
+    const showArea = strategyConfig.show_area_in_battery_view === true;
     const critical: string[] = [];
     const low: string[] = [];
     const good: string[] = [];
@@ -87,13 +111,13 @@ class Simon42ViewBatteriesStrategy extends HTMLElement {
 
     const sections: LovelaceSectionConfig[] = [];
 
-    const criticalSection = createBatterySection(critical, 'critical', `< ${criticalThreshold}%`);
+    const criticalSection = createBatterySection(critical, 'critical', `< ${criticalThreshold}%`, hass, showArea);
     if (criticalSection) sections.push(criticalSection);
 
-    const lowSection = createBatterySection(low, 'low', `${criticalThreshold}% - ${lowThreshold}%`);
+    const lowSection = createBatterySection(low, 'low', `${criticalThreshold}% - ${lowThreshold}%`, hass, showArea);
     if (lowSection) sections.push(lowSection);
 
-    const goodSection = createBatterySection(good, 'good', `> ${lowThreshold}%`);
+    const goodSection = createBatterySection(good, 'good', `> ${lowThreshold}%`, hass, showArea);
     if (goodSection) sections.push(goodSection);
 
     return { type: 'sections', sections };


### PR DESCRIPTION
## Summary

Closes #130 — many users name their contact sensors generically (\"Fenster\", \"Tür\") because the room is implicit in HA's area assignment. In the batteries view this produced a list of identically-named tiles with no way to tell them apart.

This PR adds an optional `show_area_in_battery_view` toggle. When enabled, each battery tile is rendered as `\"<Area> • <friendly_name>\"` — e.g. *\"Wohnzimmer • Fenster-Batterie\"*. Area is resolved from the entity's `area_id`, falling back to its device's `area_id` if unset (same lookup the lights/covers cards use).

## Configurability

- Editor toggle in **Summaries → Show battery summary** (indented next to *Hide mobile app batteries*)
- Defaults to `false` — existing dashboards render unchanged
- Sort order, thresholds, and grouping are untouched

## Test plan

- [x] Toggle off → tiles render exactly as before
- [x] Toggle on with an entity that has an area → \"<Area> • <friendly_name>\"
- [x] Toggle on with an entity whose only area comes from its device → still shows area
- [x] Toggle on with an entity that has no area assignment anywhere → falls back to default friendly_name (no \"null •\" prefix)
- [x] TypeScript clean (`tsc --noEmit`)

---
_AI-drafted under human supervision by @TheDave94. Tested live on Home Assistant — fully when the relevant hardware is available, otherwise only along the code paths that don't require an actual sensor of that type._