### PR TITLE
feat(security): user-picked extra entities for Security view (closes #186)

### DIFF
--- a/src/editor/StrategyEditor.ts
+++ b/src/editor/StrategyEditor.ts
@@ -72,6 +72,7 @@ class Simon42DashboardStrategyEditor extends LitElement {
   // Entity search state (NOT @state — we call requestUpdate manually)
   private _favoriteSearch = '';
   private _roomPinSearch = '';
+  private _securityExtraSearch = '';
 
   // Cache for loaded area entities (avoid re-fetching on every render)
   private _areaEntitiesCache = new Map<string, {
@@ -1306,6 +1307,10 @@ class Simon42DashboardStrategyEditor extends LitElement {
         ${this._renderCheckbox('show-security-summary', localize('editor.show_security_summary'), showSecuritySummary,
           (checked) => this._toggleChanged('show_security_summary', checked, true))}
 
+        <div style="margin-left: 26px; margin-bottom: 8px;">
+          ${this._renderSecurityExtraEntitiesPicker()}
+        </div>
+
         ${this._renderCheckbox('show-climate-summary', localize('editor.show_climate_summary'), showClimateSummary,
           (checked) => this._toggleChanged('show_climate_summary', checked, false))}
         <div class="description">${localize('editor.show_climate_summary_desc')}</div>
@@ -1339,6 +1344,77 @@ class Simon42DashboardStrategyEditor extends LitElement {
         </div>
       </div>
     `;
+  }
+
+  private _renderSecurityExtraEntitiesPicker(): TemplateResult {
+    const extras = this._config.security_extra_entities || [];
+    const allEntities = this._getAllEntitiesForSelect();
+    const entityMap = new Map(allEntities.map((e) => [e.entity_id, e.name]));
+    const filtered = this._getFilteredEntities(this._securityExtraSearch);
+    return html`
+      <div style="font-size: 13px; font-weight: 500; color: var(--primary-text-color); margin-top: 4px; margin-bottom: 4px;">
+        ${localize('editor.security_extra_entities')}
+      </div>
+      <div class="description" style="margin-left: 0; margin-bottom: 8px;">
+        ${localize('editor.security_extra_entities_desc')}
+      </div>
+      ${extras.length > 0 ? html`
+        <div class="entity-list-container" style="margin-bottom: 8px;">
+          ${extras.map((entityId) => {
+            const name = entityMap.get(entityId) || entityId;
+            return html`
+              <div class="entity-list-item" data-entity-id=${entityId}>
+                <span class="item-info">
+                  <span class="item-name">${name}</span>
+                  <span class="item-entity-id">${entityId}</span>
+                </span>
+                <button class="btn-remove" @click=${() => this._removeSecurityExtraEntity(entityId)}>&#x2715;</button>
+              </div>
+            `;
+          })}
+        </div>
+      ` : nothing}
+      <div class="entity-search-picker">
+        <input type="text" class="entity-search-input"
+          placeholder=${localize('editor.select_entity') + '...'}
+          .value=${this._securityExtraSearch}
+          @input=${(e: Event) => { this._securityExtraSearch = (e.target as HTMLInputElement).value; this.requestUpdate(); }}
+          @blur=${() => { setTimeout(() => { this._securityExtraSearch = ''; this.requestUpdate(); }, 200); }}
+        />
+        ${this._securityExtraSearch.length >= 2 ? html`
+          <div class="entity-search-results">
+            ${filtered.length > 0
+              ? filtered.map((entity) => html`
+                <div class="entity-search-result" @mousedown=${(e: Event) => { e.preventDefault(); this._addSecurityExtraEntity(entity.entity_id); this._securityExtraSearch = ''; this.requestUpdate(); }}>
+                  <span class="entity-search-name">${entity.name}</span>
+                  <span class="entity-search-id">${entity.entity_id}</span>
+                </div>
+              `)
+              : html`<div class="entity-search-no-results">${localize('editor.no_results')}</div>`
+            }
+          </div>
+        ` : nothing}
+      </div>
+    `;
+  }
+
+  private _addSecurityExtraEntity(entityId: string): void {
+    const current = this._config.security_extra_entities || [];
+    if (current.includes(entityId)) return;
+    const updated: Simon42StrategyConfig = { ...this._config, security_extra_entities: [...current, entityId] };
+    this._fireConfigChanged(updated);
+  }
+
+  private _removeSecurityExtraEntity(entityId: string): void {
+    const current = this._config.security_extra_entities || [];
+    const next = current.filter((e) => e !== entityId);
+    const updated: Simon42StrategyConfig = { ...this._config };
+    if (next.length === 0) {
+      delete updated.security_extra_entities;
+    } else {
+      updated.security_extra_entities = next;
+    }
+    this._fireConfigChanged(updated);
   }
 
   private _renderFavoritesSection(): TemplateResult {

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -70,7 +70,8 @@
     "windows_open": "Tür- & Fenstersensoren - Offen",
     "windows_closed": "Tür- & Fenstersensoren - Geschlossen",
     "smoke_gas_active": "Rauch- & Gasmelder - Alarm",
-    "smoke_gas_inactive": "Rauch- & Gasmelder - Kein Alarm"
+    "smoke_gas_inactive": "Rauch- & Gasmelder - Kein Alarm",
+    "extra_entities": "Smart-Geräte & Sonstiges"
   },
   "batteries": {
     "critical": "Kritisch",
@@ -130,6 +131,8 @@
     "show_partially_open_covers": "Teiloffene Rollos separat anzeigen",
     "show_partially_open_covers_desc": "Zeigt teiloffene Rollos (weder ganz offen noch geschlossen) in einer eigenen Gruppe an.",
     "show_security_summary": "Sicherheits-Zusammenfassung anzeigen",
+    "security_extra_entities": "Zusätzliche Entitäten in Sicherheits-Ansicht",
+    "security_extra_entities_desc": "Beliebige Entitäten (Smart-Geräte, eigene Sensoren etc.) auswählen, die unten in der Sicherheits-Ansicht als Kacheln erscheinen. Praktisch für Backofen, Herd, Bügeleisen — alles, was du vor dem Verlassen noch einmal prüfen möchtest.",
     "show_climate_summary": "Klima-Zusammenfassung anzeigen",
     "show_climate_summary_desc": "Zeigt die Klima-Zusammenfassungskarte in der Übersicht an. Zählt aktive Thermostate und Klimageräte.",
     "show_battery_summary": "Batterie-Zusammenfassung anzeigen",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -70,7 +70,8 @@
     "windows_open": "Door & Window Sensors - Open",
     "windows_closed": "Door & Window Sensors - Closed",
     "smoke_gas_active": "Smoke & Gas Detectors - Alarm",
-    "smoke_gas_inactive": "Smoke & Gas Detectors - No Alarm"
+    "smoke_gas_inactive": "Smoke & Gas Detectors - No Alarm",
+    "extra_entities": "Smart Appliances & Other"
   },
   "batteries": {
     "critical": "Critical",
@@ -130,6 +131,8 @@
     "show_partially_open_covers": "Show partially open covers separately",
     "show_partially_open_covers_desc": "Shows partially open covers (neither fully open nor closed) in a separate group.",
     "show_security_summary": "Show security summary",
+    "security_extra_entities": "Extra entities in Security view",
+    "security_extra_entities_desc": "Pick any extra entities (smart appliances, custom sensors, etc.) to show as tiles at the bottom of the Security view. Useful for ovens, cooktops, irons — anything you want a glance at before leaving the house.",
     "show_climate_summary": "Show climate summary",
     "show_climate_summary_desc": "Shows the climate summary card on the overview. Counts active thermostats and climate devices.",
     "show_battery_summary": "Show battery summary",

--- a/src/types/strategy.ts
+++ b/src/types/strategy.ts
@@ -63,6 +63,7 @@ export interface Simon42StrategyConfig {
   alarm_entity?: string;
   favorite_entities?: string[];
   room_pin_entities?: string[];
+  security_extra_entities?: string[];
 
   // Area management
   use_default_area_sort?: boolean; // default: false

--- a/src/views/SecurityViewStrategy.ts
+++ b/src/views/SecurityViewStrategy.ts
@@ -235,6 +235,7 @@ class Simon42ViewSecurityStrategy extends HTMLElement {
 
     // User-picked extra entities (smart appliances, custom sensors, etc.)
     const extraEntities: string[] = (config.config?.security_extra_entities || []).filter(
+      // eslint-disable-next-line security/detect-object-injection -- entity IDs are user-picked from the editor entity registry
       (id: string) => hass.states[id] !== undefined
     );
     if (extraEntities.length > 0) {

--- a/src/views/SecurityViewStrategy.ts
+++ b/src/views/SecurityViewStrategy.ts
@@ -233,6 +233,27 @@ class Simon42ViewSecurityStrategy extends HTMLElement {
       if (cards.length > 0) sections.push({ type: 'grid', cards });
     }
 
+    // User-picked extra entities (smart appliances, custom sensors, etc.)
+    const extraEntities: string[] = (config.config?.security_extra_entities || []).filter(
+      (id: string) => hass.states[id] !== undefined
+    );
+    if (extraEntities.length > 0) {
+      const cards: LovelaceCardConfig[] = [
+        {
+          type: 'heading',
+          heading: localize('security.extra_entities'),
+          heading_style: 'subtitle',
+          icon: 'mdi:home-alert',
+        },
+        ...extraEntities.map((e) => ({
+          type: 'tile',
+          entity: e,
+          state_content: ['state', 'last_changed'],
+        })),
+      ];
+      sections.push({ type: 'grid', cards });
+    }
+
     return { type: 'sections', sections };
   }
 }


### PR DESCRIPTION
## Summary

Closes #186 — implements the issue's *alternative* approach: let users add arbitrary entities to the Security view via the editor.

Reason for choosing this over a hardcoded oven/cooktop device-class scan: HA doesn't expose a stable device class for these — different smart appliance integrations expose different sensors and naming conventions. A user-picked list is robust across all integrations.

## What this adds

- New config: `security_extra_entities: string[]` (default `[]`)
- New section at the bottom of the Security view titled **\"Smart Appliances & Other\"** with one tile per entity
- Editor: search-driven entity picker under *Show security summary* with add/remove (order = insertion order)

## Configurability

- Empty list → no extra section rendered, existing dashboards render unchanged
- Entities that no longer exist (e.g. integration removed) are silently filtered out at render time
- Each entity rendered as a `tile` showing `state` + `last_changed`

## Test plan

- [x] Add an entity → appears in Security view as the last subsection
- [x] Add multiple → preserves insertion order
- [x] Remove an entity → vanishes immediately, empty list removes config key from YAML
- [x] Pick an entity that gets deleted from HA → falls out silently (no broken tile)
- [x] Works alongside locks / doors / garages / windows / smoke-gas
- [x] TypeScript clean

---
_AI-drafted under human supervision by @TheDave94. Tested live on Home Assistant — fully when the relevant hardware is available, otherwise only along the code paths that don't require an actual sensor of that type._