### PR TITLE
feat(areas): independent toggle for open-window/door alerts on area cards (closes #140)

### DIFF
--- a/src/editor/StrategyEditor.ts
+++ b/src/editor/StrategyEditor.ts
@@ -1418,6 +1418,7 @@ class Simon42DashboardStrategyEditor extends LitElement {
     const groupByFloors = this._config.group_by_floors === true;
     const showSwitchesOnAreas = this._config.show_switches_on_areas === true;
     const showAlertsOnAreas = this._config.show_alerts_on_areas === true;
+    const showWindowAlertsOnAreas = this._config.show_window_alerts_on_areas === true;
     const showLocksInRooms = this._config.show_locks_in_rooms === true;
     const showAutomationsInRooms = this._config.show_automations_in_rooms === true;
     const showScriptsInRooms = this._config.show_scripts_in_rooms === true;
@@ -1442,6 +1443,10 @@ class Simon42DashboardStrategyEditor extends LitElement {
         ${this._renderCheckbox('show-alerts-on-areas', localize('editor.show_alerts_on_areas'), showAlertsOnAreas,
           (checked) => this._toggleChanged('show_alerts_on_areas', checked, false))}
         <div class="description">${localize('editor.show_alerts_on_areas_desc')}</div>
+
+        ${this._renderCheckbox('show-window-alerts-on-areas', localize('editor.show_window_alerts_on_areas'), showWindowAlertsOnAreas,
+          (checked) => this._toggleChanged('show_window_alerts_on_areas', checked, false))}
+        <div class="description">${localize('editor.show_window_alerts_on_areas_desc')}</div>
 
         ${this._renderCheckbox('show-locks-in-rooms', localize('editor.show_locks_in_rooms'), showLocksInRooms,
           (checked) => this._toggleChanged('show_locks_in_rooms', checked, false))}

--- a/src/sections/AreasSection.ts
+++ b/src/sections/AreasSection.ts
@@ -69,12 +69,22 @@ const ALERT_DEVICE_CLASSES = new Set([
   'smoke', 'gas', 'heat', 'cold', 'safety', 'tamper', 'vibration',
 ]);
 
+// Window/door alerts are gated by a separate toggle (show_window_alerts_on_areas)
+// because they're less universally desired — many users have permanent contact
+// sensors on doors that they don't want as constant "alerts" on the overview.
+const WINDOW_ALERT_DEVICE_CLASSES = new Set(['window', 'door', 'opening', 'garage_door']);
+
 /**
  * Pre-computes which binary sensor alert classes exist in this area.
  * Only returns device classes from the allowlist that have at least one
  * binary_sensor entity, so the area card doesn't scan all entities at render time.
  */
-function getAreaAlertClasses(areaId: string, hass: HomeAssistant): string[] {
+function getAreaAlertClasses(
+  areaId: string,
+  hass: HomeAssistant,
+  includeStandardAlerts: boolean,
+  includeWindowAlerts: boolean
+): string[] {
   const areaEntities = Registry.getVisibleEntitiesForArea(areaId);
   if (areaEntities.length === 0) return [];
 
@@ -86,7 +96,9 @@ function getAreaAlertClasses(areaId: string, hass: HomeAssistant): string[] {
 
     const state = hass.states[entity.entity_id];
     const deviceClass = state?.attributes?.device_class as string | undefined;
-    if (deviceClass && ALERT_DEVICE_CLASSES.has(deviceClass)) found.add(deviceClass);
+    if (!deviceClass) continue;
+    if (includeStandardAlerts && ALERT_DEVICE_CLASSES.has(deviceClass)) found.add(deviceClass);
+    else if (includeWindowAlerts && WINDOW_ALERT_DEVICE_CLASSES.has(deviceClass)) found.add(deviceClass);
   }
 
   return [...found];
@@ -109,9 +121,12 @@ function buildAreaCard(area: AreaRegistryEntry, hass: HomeAssistant): LovelaceCa
     sensorClasses.push('humidity');
   }
 
-  // Pre-filter alert classes if enabled
-  const alertClasses = Registry.config.show_alerts_on_areas
-    ? getAreaAlertClasses(area.area_id, hass)
+  // Pre-filter alert classes if enabled. Window/door classes are gated by a
+  // separate toggle so users can opt into open-window badges independently.
+  const showAlerts = Registry.config.show_alerts_on_areas === true;
+  const showWindowAlerts = Registry.config.show_window_alerts_on_areas === true;
+  const alertClasses = showAlerts || showWindowAlerts
+    ? getAreaAlertClasses(area.area_id, hass, showAlerts, showWindowAlerts)
     : undefined;
 
   return {

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -158,6 +158,8 @@
     "show_switches_on_areas_desc": "Zeigt Schalter (Switches) als Controls auf den Bereichskarten in der Übersicht an. ⚠️ Stelle sicher, dass alle Schalter, die nicht geschaltet werden können oder sollen, über die Entitäts-Einstellungen auf 'Nicht sichtbar' gestellt sind!",
     "show_alerts_on_areas": "Alert-Icons auf Bereichskarten anzeigen",
     "show_alerts_on_areas_desc": "Zeigt Alert-Icons (z.B. Bewegung, Feuchtigkeit, Wärme) auf den Bereichskarten an, wenn ein Binärsensor im Bereich aktiv ist.",
+    "show_window_alerts_on_areas": "Offene Fenster/Türen als Icon auf Bereichskarten anzeigen",
+    "show_window_alerts_on_areas_desc": "Zeigt ein Alert-Icon auf der Bereichskarte, sobald ein Fenster-, Tür-, Öffnungs- oder Garagentor-Kontaktsensor im Bereich offen ist. Unabhängig vom regulären Alert-Toggle oben.",
     "show_locks_in_rooms": "Schlösser in Raum-Ansichten anzeigen",
     "show_locks_in_rooms_desc": "Zeigt Schlösser (z.B. Nuki) in den jeweiligen Raum-Ansichten an. Schlösser erscheinen unabhängig davon immer in der Sicherheits-Übersicht.",
     "show_automations_in_rooms": "Automationen in Raum-Ansichten anzeigen",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -158,6 +158,8 @@
     "show_switches_on_areas_desc": "Shows switches as controls on the area cards in the overview. Home Assistant hides these by default.",
     "show_alerts_on_areas": "Show alert icons on area cards",
     "show_alerts_on_areas_desc": "Shows alert icons (e.g. motion, moisture, heat) on area cards when a binary sensor in the area is active.",
+    "show_window_alerts_on_areas": "Show open window/door icons on area cards",
+    "show_window_alerts_on_areas_desc": "Shows an alert icon on the area card whenever a window, door, opening, or garage-door contact sensor in that area is open. Independent of the regular alert toggle above.",
     "show_locks_in_rooms": "Show locks in room views",
     "show_locks_in_rooms_desc": "Shows locks (e.g. Nuki) in the respective room views. Locks always appear in the security overview regardless.",
     "show_automations_in_rooms": "Show automations in room views",

--- a/src/types/strategy.ts
+++ b/src/types/strategy.ts
@@ -47,6 +47,7 @@ export interface Simon42StrategyConfig {
   show_door_contacts_in_rooms?: boolean; // default: false
   show_switches_on_areas?: boolean; // default: false
   show_alerts_on_areas?: boolean; // default: false
+  show_window_alerts_on_areas?: boolean; // default: false
   energy_link_dashboard?: boolean; // default: true
 
   // Layout


### PR DESCRIPTION
## Summary

Closes #140 — adds `show_window_alerts_on_areas` (default `false`), an independent toggle from the existing `show_alerts_on_areas`. With it enabled, the area cards on the overview will show an alert icon whenever any `window` / `door` / `opening` / `garage_door` binary_sensor in that area is *on*.

## Why a separate toggle

The existing `show_alerts_on_areas` intentionally excludes window/door device classes — many users have permanent contact sensors they don't want as constant alert badges. The issue author explicitly asked for independent control: \"eine Option ... mit der konfiguriert werden kann, ob Bewegung/Presence oder geöffnete Fenster per Badge ... visualisiert werden.\"

Splitting the two means you can:
- enable only `show_window_alerts_on_areas` to surface open windows while leaving motion alerts off
- enable both for full coverage
- enable only `show_alerts_on_areas` to keep the existing behaviour

## Implementation

- `getAreaAlertClasses(area, hass, includeStandard, includeWindows)` now takes two flags and filters the per-area scan accordingly
- `buildAreaCard` reads both flags from `Registry.config`; `alert_classes` is only attached when at least one flag is on
- Window alert classes: `['window', 'door', 'opening', 'garage_door']`
- Standard alert classes (unchanged): `motion`, `occupancy`, `sound`, `moisture`, `smoke`, `gas`, `heat`, `cold`, `safety`, `tamper`, `vibration`

## Test plan

- [x] Default (both off) → existing dashboards render unchanged (no `alert_classes` attached)
- [x] Only standard on → motion etc. still works, windows ignored
- [x] Only windows on → windows/doors badge, motion/etc. ignored
- [x] Both on → both badge types visible
- [x] Areas without any matching binary_sensor → `alert_classes` omitted (no empty badge)
- [x] TypeScript clean

---
_AI-drafted under human supervision by @TheDave94. Tested live on Home Assistant — fully when the relevant hardware is available, otherwise only along the code paths that don't require an actual sensor of that type._