### PR TITLE
feat(rooms): optional toggle to hide cameras in room views (closes #128)

### DIFF
--- a/src/editor/StrategyEditor.ts
+++ b/src/editor/StrategyEditor.ts
@@ -1421,6 +1421,7 @@ class Simon42DashboardStrategyEditor extends LitElement {
     const showLocksInRooms = this._config.show_locks_in_rooms === true;
     const showAutomationsInRooms = this._config.show_automations_in_rooms === true;
     const showScriptsInRooms = this._config.show_scripts_in_rooms === true;
+    const showCamerasInRooms = this._config.show_cameras_in_rooms !== false;
     const useDefaultAreaSort = this._config.use_default_area_sort === true;
 
     const allAreas = Object.values(this._hass!.areas).sort((a, b) => a.name.localeCompare(b.name));
@@ -1454,6 +1455,10 @@ class Simon42DashboardStrategyEditor extends LitElement {
         ${this._renderCheckbox('show-scripts-in-rooms', localize('editor.show_scripts_in_rooms'), showScriptsInRooms,
           (checked) => this._toggleChanged('show_scripts_in_rooms', checked, false))}
         <div class="description">${localize('editor.show_scripts_in_rooms_desc')}</div>
+
+        ${this._renderCheckbox('show-cameras-in-rooms', localize('editor.show_cameras_in_rooms'), showCamerasInRooms,
+          (checked) => this._toggleChanged('show_cameras_in_rooms', checked, true))}
+        <div class="description">${localize('editor.show_cameras_in_rooms_desc')}</div>
 
         ${this._renderCheckbox('use-default-area-sort', localize('editor.use_default_area_sort'), useDefaultAreaSort,
           (checked) => this._toggleChanged('use_default_area_sort', checked, false))}

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -164,6 +164,8 @@
     "show_automations_in_rooms_desc": "Zeigt dem Bereich zugeordnete Automationen in den jeweiligen Raum-Ansichten an.",
     "show_scripts_in_rooms": "Skripte in Raum-Ansichten anzeigen",
     "show_scripts_in_rooms_desc": "Zeigt dem Bereich zugeordnete Skripte in den jeweiligen Raum-Ansichten an.",
+    "show_cameras_in_rooms": "Kameras in Raum-Ansichten anzeigen",
+    "show_cameras_in_rooms_desc": "Zeigt dem Bereich zugeordnete Kameras in den jeweiligen Raum-Ansichten an. Deaktivieren, um Kameras aus dem Dashboard zu nehmen, ohne sie global auf „nicht sichtbar“ zu stellen.",
     "show_window_contacts_in_rooms": "Fensterkontakte in Raum-Ansichten anzeigen",
     "show_window_contacts_in_rooms_desc": "Zeigt Fensterkontakte als Badges in den jeweiligen Raum-Ansichten an.",
     "show_door_contacts_in_rooms": "Türkontakte in Raum-Ansichten anzeigen",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -164,6 +164,8 @@
     "show_automations_in_rooms_desc": "Shows automations assigned to the area in the respective room views.",
     "show_scripts_in_rooms": "Show scripts in room views",
     "show_scripts_in_rooms_desc": "Shows scripts assigned to the area in the respective room views.",
+    "show_cameras_in_rooms": "Show cameras in room views",
+    "show_cameras_in_rooms_desc": "Shows cameras assigned to the area in the respective room views. Disable to keep cameras out of the dashboard without hiding them globally.",
     "show_window_contacts_in_rooms": "Show window contacts in room views",
     "show_window_contacts_in_rooms_desc": "Shows window contacts as badges in the respective room views.",
     "show_door_contacts_in_rooms": "Show door contacts in room views",

--- a/src/types/strategy.ts
+++ b/src/types/strategy.ts
@@ -43,6 +43,7 @@ export interface Simon42StrategyConfig {
   show_locks_in_rooms?: boolean; // default: false
   show_automations_in_rooms?: boolean; // default: false
   show_scripts_in_rooms?: boolean; // default: false
+  show_cameras_in_rooms?: boolean; // default: true
   show_window_contacts_in_rooms?: boolean; // default: false
   show_door_contacts_in_rooms?: boolean; // default: false
   show_switches_on_areas?: boolean; // default: false

--- a/src/views/RoomViewStrategy.ts
+++ b/src/views/RoomViewStrategy.ts
@@ -142,7 +142,7 @@ class Simon42ViewRoomStrategy extends HTMLElement {
         roomEntities.scripts.push(entityId);
         continue;
       }
-      if (domain === 'camera') {
+      if (domain === 'camera' && dashboardConfig.show_cameras_in_rooms !== false) {
         roomEntities.cameras.push(entityId);
         continue;
       }


### PR DESCRIPTION
## Summary

Closes #128 — adds an editor toggle to hide camera entities from the room views without forcing users to flip them to *Not visible* globally (which would also hide them from any manual dashboards they use elsewhere).

## Configurability

New config: `show_cameras_in_rooms?: boolean` (default `true`).

When set to `false`, the camera-domain branch in the room classify loop is skipped, so the camera section is never assembled. Editor toggle in **Areas & Rooms** under *Show scripts in room views*.

## Test plan

- [x] Default → cameras still shown (no regression)
- [x] Toggle off → camera section disappears from the affected room views
- [x] Toggle off + Reolink/Aqara device → none of the per-device extras (spotlight, doorbell, etc.) leak through either, because they're gated inside the same camera section block
- [x] TypeScript clean

---
_AI-drafted under human supervision by @TheDave94. Tested live on Home Assistant — fully when the relevant hardware is available, otherwise only along the code paths that don't require an actual sensor of that type._