### PR TITLE
feat(batteries): optional filter for Battery Notes helper entities (closes #173)

### DIFF
--- a/src/cards/SummaryCard.ts
+++ b/src/cards/SummaryCard.ts
@@ -20,6 +20,7 @@ type SummaryType = 'lights' | 'covers' | 'security' | 'batteries' | 'climate';
 interface SummaryCardConfig {
   summary_type: SummaryType;
   hide_mobile_app_batteries?: boolean;
+  hide_battery_notes_entities?: boolean;
   battery_critical_threshold?: number;
 }
 

--- a/src/editor/StrategyEditor.ts
+++ b/src/editor/StrategyEditor.ts
@@ -1262,6 +1262,7 @@ class Simon42DashboardStrategyEditor extends LitElement {
     const showClimateSummary = this._config.show_climate_summary === true;
     const showBatterySummary = this._config.show_battery_summary !== false;
     const hideMobileAppBatteries = this._config.hide_mobile_app_batteries === true;
+    const hideBatteryNotesEntities = this._config.hide_battery_notes_entities === true;
     const batteryCriticalThreshold = this._config.battery_critical_threshold ?? 20;
     const batteryLowThreshold = this._config.battery_low_threshold ?? 50;
 
@@ -1317,6 +1318,10 @@ class Simon42DashboardStrategyEditor extends LitElement {
           ${this._renderCheckbox('hide-mobile-app-batteries', localize('editor.hide_mobile_app_batteries'), hideMobileAppBatteries,
             (checked) => this._toggleChanged('hide_mobile_app_batteries', checked, false))}
           <div class="description">${localize('editor.hide_mobile_app_batteries_desc')}</div>
+
+          ${this._renderCheckbox('hide-battery-notes-entities', localize('editor.hide_battery_notes_entities'), hideBatteryNotesEntities,
+            (checked) => this._toggleChanged('hide_battery_notes_entities', checked, false))}
+          <div class="description">${localize('editor.hide_battery_notes_entities_desc')}</div>
 
           <div style="font-size: 13px; font-weight: 500; color: var(--primary-text-color); margin-top: 12px; margin-bottom: 4px;">
             ${localize('editor.battery_thresholds')}

--- a/src/sections/OverviewSection.ts
+++ b/src/sections/OverviewSection.ts
@@ -129,6 +129,7 @@ export function createOverviewSection(data: OverviewSectionParams): LovelaceSect
       summary_type: 'batteries',
       areas_options: config.areas_options || {},
       hide_mobile_app_batteries: config.hide_mobile_app_batteries,
+      hide_battery_notes_entities: config.hide_battery_notes_entities,
       battery_critical_threshold: config.battery_critical_threshold,
     });
   }

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -135,6 +135,8 @@
     "show_battery_summary": "Batterie-Zusammenfassung anzeigen",
     "hide_mobile_app_batteries": "Mobile-App-Batterien ausblenden",
     "hide_mobile_app_batteries_desc": "Blendet Batterien von Smartphones, Tablets und Watches (Mobile App) in der Batterie-Übersicht und -Zusammenfassung aus.",
+    "hide_battery_notes_entities": "Battery-Notes-Hilfsentitäten ausblenden",
+    "hide_battery_notes_entities_desc": "Blendet die von der HACS-Integration „Battery Notes“ erzeugten Hilfsentitäten (battery_type, battery_quantity, battery_low) in der Batterie-Übersicht und -Zusammenfassung aus. In anderen Dashboards bleiben sie nutzbar — hier sind sie aber kein echter Ladestand.",
     "battery_thresholds": "Batterie-Schwellwerte",
     "battery_critical_below": "Kritisch unter",
     "battery_low_below": "Niedrig unter",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -135,6 +135,8 @@
     "show_battery_summary": "Show battery summary",
     "hide_mobile_app_batteries": "Hide mobile app batteries",
     "hide_mobile_app_batteries_desc": "Hides batteries from smartphones, tablets, and watches (Mobile App) from the battery overview and summary.",
+    "hide_battery_notes_entities": "Hide Battery Notes helper entities",
+    "hide_battery_notes_entities_desc": "Hides helper entities created by the HACS Battery Notes integration (battery_type, battery_quantity, battery_low) from the battery view and summary. They're useful elsewhere but aren't real battery levels.",
     "battery_thresholds": "Battery thresholds",
     "battery_critical_below": "Critical below",
     "battery_low_below": "Low below",

--- a/src/types/strategy.ts
+++ b/src/types/strategy.ts
@@ -38,6 +38,7 @@ export interface Simon42StrategyConfig {
   show_battery_summary?: boolean; // default: true
   show_climate_summary?: boolean; // default: false
   hide_mobile_app_batteries?: boolean; // default: false
+  hide_battery_notes_entities?: boolean; // default: false
   battery_critical_threshold?: number; // default: 20
   battery_low_threshold?: number; // default: 50
   show_locks_in_rooms?: boolean; // default: false

--- a/src/utils/entity-filter.ts
+++ b/src/utils/entity-filter.ts
@@ -87,6 +87,13 @@ export function getBatteryEntities(hass: HomeAssistant, config: Simon42StrategyC
     if (config.hide_mobile_app_batteries) {
       if (entry?.platform === 'mobile_app') return false;
     }
+    // Platform-specific filter: hide Battery Notes helper entities if configured.
+    // Battery Notes (HACS integration) creates auxiliary entities per device —
+    // *_battery_type, *_battery_quantity, *_battery_low — that aren't real
+    // battery levels and shouldn't be grouped into Critical/Low/Good.
+    if (config.hide_battery_notes_entities) {
+      if (entry?.platform === 'battery_notes') return false;
+    }
 
     if (entityId.startsWith('binary_sensor.') && entityId.includes('battery')) return true;
     if (state.attributes?.device_class === 'battery' && state.attributes?.unit_of_measurement === '%') return true;


### PR DESCRIPTION
## Summary

Closes #173 — the HACS [Battery Notes](https://github.com/andrew-codechimp/HA-Battery-Notes) integration creates several helper entities per device (\`battery_type\`, \`battery_quantity\`, \`battery_low\`). The issue author uses these elsewhere (e.g. to track which battery sizes to keep in stock) and doesn't want to hide them globally, but they shouldn't show up in the strategy's *Batteries* view since they're not actual charge levels — the string states (\"AA\", \"CR2032\") were being bucketed as *Critical* via the existing isNaN fallback.

## Configurability

New config: \`hide_battery_notes_entities?: boolean\` (default \`false\`).

When set, entities with \`platform === 'battery_notes'\` are filtered out of both the *Batteries* view AND the *Battery summary* count (so the summary tile and the view agree). Editor toggle under *Hide mobile app batteries* — same indentation, same pattern.

## Test plan

- [x] Default off → existing dashboards render unchanged
- [x] Toggle on with Battery Notes installed → battery_type / battery_quantity / battery_low entities disappear from the batteries view AND the summary count drops accordingly
- [x] Toggle on without Battery Notes installed → no-op (filter just doesn't match anything)
- [x] Real device-level battery sensors are unaffected
- [x] TypeScript clean

---
_AI-drafted under human supervision by @TheDave94. Tested live on Home Assistant — fully when the relevant hardware is available, otherwise only along the code paths that don't require an actual sensor of that type._