### PR TITLE
feat(badges): auto-detect soil moisture sensors in room views (closes #216)

### DIFF
--- a/src/types/strategy.ts
+++ b/src/types/strategy.ts
@@ -177,6 +177,7 @@ export interface SensorEntities {
   occupancy: string[];
   illuminance: string[];
   absolute_humidity: string[];
+  soil_moisture: string[];
   battery: string[];
   window: string[];
   door: string[];

--- a/src/utils/badge-utils.ts
+++ b/src/utils/badge-utils.ts
@@ -61,6 +61,10 @@ export function isBadgeCandidate(
   if (domain === 'sensor') {
     // Battery (caller must check threshold)
     if (deviceClass === 'battery' || entityId.includes('battery')) return true;
+    // Soil/plant moisture sensors (e.g. plant.*, soil moisture %). Check before
+    // the generic '%'-unit reject below — soil moisture also uses '%' but is
+    // semantically distinct from air humidity.
+    if (deviceClass === 'moisture') return true;
     // Skip temperature/humidity (handled by HA area config, not auto-detected)
     if (deviceClass === 'temperature' || unit === '°C' || unit === '°F') return false;
     if (deviceClass === 'humidity' || unit === '%') return false;

--- a/src/views/RoomViewStrategy.ts
+++ b/src/views/RoomViewStrategy.ts
@@ -73,6 +73,7 @@ class Simon42ViewRoomStrategy extends HTMLElement {
       occupancy: [],
       illuminance: [],
       absolute_humidity: [],
+      soil_moisture: [],
       battery: [],
       window: [],
       door: [],
@@ -158,6 +159,13 @@ class Simon42ViewRoomStrategy extends HTMLElement {
         // assigned in HA area settings (area.temperature_entity_id / humidity_entity_id).
         // No auto-detection — avoids wrong sensors (e.g. heater temperature).
         if (deviceClass === 'temperature' || unit === '°C' || unit === '°F') continue;
+        // Soil/plant moisture sensors are auto-detected (device_class === 'moisture'
+        // on sensor.* — distinct from binary_sensor.moisture which means a leak).
+        // Check before the '%' fallthrough so we don't lose them.
+        if (deviceClass === 'moisture') {
+          sensorEntities.soil_moisture.push(entityId);
+          continue;
+        }
         if (deviceClass === 'humidity' || unit === '%') continue;
         if (unit === 'g/m³') {
           sensorEntities.absolute_humidity.push(entityId);
@@ -287,6 +295,7 @@ class Simon42ViewRoomStrategy extends HTMLElement {
       [sensorEntities.motion, 'motion'],
       [sensorEntities.occupancy, 'occupancy'],
       [sensorEntities.absolute_humidity, 'moisture'],
+      [sensorEntities.soil_moisture, 'moisture'],
       [sensorEntities.smoke, 'smoke'],
       [sensorEntities.gas, 'gas'],
     ];


### PR DESCRIPTION
## Summary

Closes #216 — soil/plant moisture sensors (device_class \`moisture\` on \`sensor.*\` — e.g. Xiaomi Mi Flora, Zigbee soil probes, smart watering systems) weren't being picked up as room badges, so the issue author's garden sensors didn't appear in the *Garten* room view.

## Why it was missed before

\`isBadgeCandidate\` had a generic *\"reject anything with unit '%'\"* clause for filtering out air humidity. Soil moisture also uses '%', so it was being rejected. The fix: check \`device_class === 'moisture'\` (the HA-standard device class for soil moisture) **before** the '%' fallthrough.

## Changes

- \`badge-utils.ts\`: detect \`device_class === 'moisture'\` on sensors before the '%' reject
- \`RoomViewStrategy\`: per-area classifier branch + new \`SensorEntities.soil_moisture\` bucket + first match added to the single-match badge candidate list
- \`types/strategy.ts\`: \`SensorEntities.soil_moisture: string[]\`

Same auto-detection pattern as pm25 / co2 / motion / etc. — no toggle, no config required.

## Test plan

- [x] Sensor with \`device_class: moisture\` and unit \`%\` appears as a blue badge in its area's room view
- [x] No regression on existing \`absolute_humidity\` (g/m³) badges
- [x] \`binary_sensor\` with \`device_class: moisture\` (water leak) is still handled by the existing security path, not the room badge path
- [x] Plain humidity sensors (device_class: humidity, unit: %) are still ignored (no auto-detection — by design, per repo convention)
- [x] TypeScript clean

---
_AI-drafted under human supervision by @TheDave94. Tested live on Home Assistant — fully when the relevant hardware is available, otherwise only along the code paths that don't require an actual sensor of that type._