### PR TITLE
fix(areas): return area-controls in canonical order, not entity-iteration order (closes #201)

### DIFF
--- a/src/sections/AreasSection.ts
+++ b/src/sections/AreasSection.ts
@@ -58,7 +58,13 @@ function getAreaControls(areaId: string, hass: HomeAssistant): ControlDomain[] {
     }
   }
 
-  return [...found];
+  // Return in canonical CONTROL_DOMAINS order, not entity-iteration order.
+  // Set preserves insertion order in JS, which depends on the order entities
+  // happened to be added — that varies between areas (because the entity
+  // registry returns entities in registration order), so without an explicit
+  // sort, two areas with the same control mix could produce shortcut icons
+  // in different orders. See issue #201.
+  return CONTROL_DOMAINS.filter((d) => found.has(d));
 }
 
 // Alert-relevant binary sensor device classes.


### PR DESCRIPTION
## Summary

Closes #201 — area card shortcut icons (light, cover-shutter, etc.) could appear in a different order between rooms with the same control mix. The reporter saw \"light then shutter\" in most rooms but \"shutter then light\" in one specific room, with no obvious reason.

## Root cause

\`getAreaControls\` populated a \`Set<ControlDomain>\` while iterating \`Registry.getVisibleEntitiesForArea(...)\` and returned \`[...found]\`. JS \`Set\` preserves *insertion* order, and the entity registry returns entities in registration order, which differs across areas (depending on when each device was added to HA). So:

- Room A registered the light first, then the cover → set is `light, cover-shutter` → renders \"light, shutter\"
- Room B registered the cover first → set is `cover-shutter, light` → renders \"shutter, light\"

## Fix

Replace `[...found]` with `CONTROL_DOMAINS.filter((d) => found.has(d))`, which uses the canonical declaration order of `CONTROL_DOMAINS` (light → fan → switch → cover-shutter → ... → cover-damper). Rooms whose icons happened to be in that order are unchanged; rooms with reversed order now align with the rest.

## Test plan

- [x] Two rooms with the same control mix render shortcut icons in the same order
- [x] Rooms with different mixes still only show the icons that apply
- [x] TypeScript clean

---
_AI-drafted under human supervision by @TheDave94. Tested live on Home Assistant — fully when the relevant hardware is available, otherwise only along the code paths that don't require an actual sensor of that type._