### PR TITLE
feat(plants): new optional Plants section on overview

### DIFF
--- a/src/editor/StrategyEditor.ts
+++ b/src/editor/StrategyEditor.ts
@@ -1059,6 +1059,8 @@ class Simon42DashboardStrategyEditor extends LitElement {
         return this._config.show_weather === false;
       case 'energy':
         return this._config.show_energy === false;
+      case 'plants':
+        return this._config.show_plants_section !== true;
       default:
         return false;
     }
@@ -1070,10 +1072,11 @@ class Simon42DashboardStrategyEditor extends LitElement {
     ['areas', { icon: 'mdi:floor-plan', labelKey: 'sections.areas' }],
     ['weather', { icon: 'mdi:weather-partly-cloudy', labelKey: 'sections.weather' }],
     ['energy', { icon: 'mdi:lightning-bolt', labelKey: 'sections.energy' }],
+    ['plants', { icon: 'mdi:flower-tulip', labelKey: 'sections.plants' }],
   ]);
 
   private _isSectionToggleable(key: SectionKey): boolean {
-    return key === 'weather' || key === 'energy';
+    return key === 'weather' || key === 'energy' || key === 'plants';
   }
 
   private _toggleSectionVisibility(key: SectionKey, visible: boolean): void {
@@ -1081,6 +1084,8 @@ class Simon42DashboardStrategyEditor extends LitElement {
       this._toggleChanged('show_weather', visible, true);
     } else if (key === 'energy') {
       this._toggleChanged('show_energy', visible, true);
+    } else if (key === 'plants') {
+      this._toggleChanged('show_plants_section', visible, false);
     }
   }
 

--- a/src/sections/PlantsSection.ts
+++ b/src/sections/PlantsSection.ts
@@ -1,0 +1,50 @@
+// ====================================================================
+// Plants Section Builder
+// ====================================================================
+// Renders a "Plants" section on the overview when the user has plant.*
+// entities. Auto-hides when none exist, regardless of the toggle.
+// ====================================================================
+
+import type { HomeAssistant } from '../types/homeassistant';
+import type { LovelaceCardConfig, LovelaceSectionConfig } from '../types/lovelace';
+import { Registry } from '../Registry';
+import { localize } from '../utils/localize';
+
+/**
+ * Creates the plants section.
+ * Returns null when there are no plant.* entities in HA, even if the
+ * toggle is enabled — modular auto-hide.
+ */
+export function createPlantsSection(
+  hass: HomeAssistant,
+  enabled: boolean,
+  hideHeading: boolean = false
+): LovelaceSectionConfig | null {
+  if (!enabled) return null;
+
+  const plantIds = Registry.getVisibleEntityIdsForDomain('plant').filter(
+    (id) => hass.states[id] !== undefined
+  );
+  if (plantIds.length === 0) return null;
+
+  const cards: LovelaceCardConfig[] = [];
+  if (!hideHeading) {
+    cards.push({
+      type: 'heading',
+      heading_style: 'title',
+      heading: localize('sections.plants'),
+      icon: 'mdi:flower-tulip',
+    });
+  }
+
+  for (const entityId of plantIds) {
+    cards.push({
+      type: 'tile',
+      entity: entityId,
+      vertical: false,
+      state_content: ['state'],
+    });
+  }
+
+  return { type: 'grid', cards };
+}

--- a/src/sections/PlantsSection.ts
+++ b/src/sections/PlantsSection.ts
@@ -23,6 +23,7 @@ export function createPlantsSection(
   if (!enabled) return null;
 
   const plantIds = Registry.getVisibleEntityIdsForDomain('plant').filter(
+    // eslint-disable-next-line security/detect-object-injection -- entity IDs from Registry
     (id) => hass.states[id] !== undefined
   );
   if (plantIds.length === 0) return null;

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -18,7 +18,8 @@
     "areas": "Bereiche",
     "areas_other": "Weitere Bereiche",
     "weather": "Wetter",
-    "energy": "Energie"
+    "energy": "Energie",
+    "plants": "Pflanzen"
   },
   "summary": {
     "lights_on_one": "Licht an",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -18,7 +18,8 @@
     "areas": "Areas",
     "areas_other": "Other Areas",
     "weather": "Weather",
-    "energy": "Energy"
+    "energy": "Energy",
+    "plants": "Plants"
   },
   "summary": {
     "lights_on_one": "light on",

--- a/src/types/strategy.ts
+++ b/src/types/strategy.ts
@@ -8,7 +8,7 @@
 
 // -- Section Ordering -------------------------------------------------
 
-export type SectionKey = 'overview' | 'custom_cards' | 'areas' | 'weather' | 'energy';
+export type SectionKey = 'overview' | 'custom_cards' | 'areas' | 'weather' | 'energy' | 'plants';
 
 export const DEFAULT_SECTIONS_ORDER: SectionKey[] = [
   'overview',
@@ -16,6 +16,7 @@ export const DEFAULT_SECTIONS_ORDER: SectionKey[] = [
   'areas',
   'weather',
   'energy',
+  'plants',
 ];
 
 // -- Main Strategy Config ---------------------------------------------
@@ -48,6 +49,7 @@ export interface Simon42StrategyConfig {
   show_switches_on_areas?: boolean; // default: false
   show_alerts_on_areas?: boolean; // default: false
   energy_link_dashboard?: boolean; // default: true
+  show_plants_section?: boolean; // default: false (auto-hides anyway if no plants)
 
   // Layout
   sections_order?: SectionKey[]; // default: DEFAULT_SECTIONS_ORDER

--- a/src/views/OverviewViewStrategy.ts
+++ b/src/views/OverviewViewStrategy.ts
@@ -17,6 +17,7 @@ import { createPersonBadges } from '../utils/badge-builder';
 import { createOverviewSection, createCustomCardsSection } from '../sections/OverviewSection';
 import { createAreasSection } from '../sections/AreasSection';
 import { createWeatherSection, createEnergySection } from '../sections/WeatherEnergySection';
+import { createPlantsSection } from '../sections/PlantsSection';
 import { createOverviewView } from '../utils/view-builder';
 import { timeStart, timeEnd, debugLog } from '../utils/debug';
 
@@ -25,7 +26,7 @@ import { timeStart, timeEnd, debugLog } from '../utils/debug';
  * appends any missing keys at the end (forward compatibility).
  */
 function normalizeSectionsOrder(order: SectionKey[]): SectionKey[] {
-  const validKeys = new Set<SectionKey>(['overview', 'custom_cards', 'areas', 'weather', 'energy']);
+  const validKeys = new Set<SectionKey>(['overview', 'custom_cards', 'areas', 'weather', 'energy', 'plants']);
   const seen = new Set<SectionKey>();
   const result: SectionKey[] = [];
   for (const key of order) {
@@ -111,6 +112,7 @@ class Simon42ViewOverviewStrategy extends HTMLElement {
       ['areas', areasSections],
       ['weather', createWeatherSection(weatherEntity ?? null, showWeather)],
       ['energy', createEnergySection(showEnergy, dashboardConfig.energy_link_dashboard !== false)],
+      ['plants', createPlantsSection(hass, dashboardConfig.show_plants_section === true)],
     ]);
 
     // Assemble in configured order, appending assigned custom cards to each section


### PR DESCRIPTION
## Summary

Surfaces `plant.*` entities (HA-native + the popular [OpenPlantbook](https://github.com/Olen/homeassistant-plant) custom integration) as tiles in a dedicated *Plants* section on the overview.

## Modular + auto-hide

- `show_plants_section?: boolean` defaults to `false` — no surface area change for existing users
- Even if the toggle is enabled, the section **auto-hides** when no `plant.*` entities exist in HA. Section position is honoured via `sections_order`; section visibility is honoured via the editor's section-order toggle

## Why

`plant.*` is HA-native and exposes per-plant moisture / temperature / brightness / fertility plus a derived `problem` state when any reading is out-of-range — exactly the kind of glance-relevant info a smart home dashboard should surface, but currently no popular community dashboard does it.

## Test plan

- [x] Default (toggle off) → no section, no behaviour change
- [x] Toggle on with plant entities → section appears, one tile per plant, current state shown
- [x] Toggle on without plant entities → section auto-hidden (no empty heading)
- [x] Position respected in `sections_order` (defaults to end, after energy)
- [x] TypeScript clean

---
_AI-drafted under human supervision by @TheDave94. Tested live on Home Assistant — fully when the relevant hardware is available, otherwise only along the code paths that don't require an actual sensor of that type._