### PR TITLE
feat(agenda): optional Agenda section using HA's built-in calendar card

### DIFF
--- a/src/editor/StrategyEditor.ts
+++ b/src/editor/StrategyEditor.ts
@@ -1059,6 +1059,8 @@ class Simon42DashboardStrategyEditor extends LitElement {
         return this._config.show_weather === false;
       case 'energy':
         return this._config.show_energy === false;
+      case 'agenda':
+        return this._config.show_agenda_section !== true;
       default:
         return false;
     }
@@ -1070,10 +1072,11 @@ class Simon42DashboardStrategyEditor extends LitElement {
     ['areas', { icon: 'mdi:floor-plan', labelKey: 'sections.areas' }],
     ['weather', { icon: 'mdi:weather-partly-cloudy', labelKey: 'sections.weather' }],
     ['energy', { icon: 'mdi:lightning-bolt', labelKey: 'sections.energy' }],
+    ['agenda', { icon: 'mdi:calendar', labelKey: 'sections.agenda' }],
   ]);
 
   private _isSectionToggleable(key: SectionKey): boolean {
-    return key === 'weather' || key === 'energy';
+    return key === 'weather' || key === 'energy' || key === 'agenda';
   }
 
   private _toggleSectionVisibility(key: SectionKey, visible: boolean): void {
@@ -1081,6 +1084,8 @@ class Simon42DashboardStrategyEditor extends LitElement {
       this._toggleChanged('show_weather', visible, true);
     } else if (key === 'energy') {
       this._toggleChanged('show_energy', visible, true);
+    } else if (key === 'agenda') {
+      this._toggleChanged('show_agenda_section', visible, false);
     }
   }
 

--- a/src/sections/AgendaSection.ts
+++ b/src/sections/AgendaSection.ts
@@ -31,6 +31,7 @@ export function createAgendaSection(
 
   // All calendar.* entities visible in this hass instance (no_dboard / hidden filtered)
   const visible = Registry.getVisibleEntityIdsForDomain('calendar').filter(
+    // eslint-disable-next-line security/detect-object-injection -- entity IDs from Registry
     (id) => hass.states[id] !== undefined
   );
 

--- a/src/sections/AgendaSection.ts
+++ b/src/sections/AgendaSection.ts
@@ -1,0 +1,66 @@
+// ====================================================================
+// Agenda Section Builder
+// ====================================================================
+// Renders an "Agenda" section on the overview using HA's built-in
+// `calendar` card. Auto-hides when no calendar.* entities exist.
+// ====================================================================
+
+import type { HomeAssistant } from '../types/homeassistant';
+import type { LovelaceCardConfig, LovelaceSectionConfig } from '../types/lovelace';
+import { Registry } from '../Registry';
+import { localize } from '../utils/localize';
+
+/**
+ * Creates the agenda section.
+ * Returns null when there are no calendar entities (or none selected),
+ * even if the toggle is enabled — modular auto-hide.
+ *
+ * @param hass HA state
+ * @param enabled toggle from config
+ * @param calendarEntities optional explicit list (config). When empty/undefined,
+ *                        all calendar.* entities are included.
+ * @param hideHeading whether the section heading should be suppressed
+ */
+export function createAgendaSection(
+  hass: HomeAssistant,
+  enabled: boolean,
+  calendarEntities: string[] | undefined,
+  hideHeading: boolean = false
+): LovelaceSectionConfig | null {
+  if (!enabled) return null;
+
+  // All calendar.* entities visible in this hass instance (no_dboard / hidden filtered)
+  const visible = Registry.getVisibleEntityIdsForDomain('calendar').filter(
+    (id) => hass.states[id] !== undefined
+  );
+
+  // Pick configured list (filtered to existing) OR fall back to all visible
+  let selected: string[];
+  if (Array.isArray(calendarEntities) && calendarEntities.length > 0) {
+    selected = calendarEntities.filter((id) => visible.includes(id));
+  } else {
+    selected = visible;
+  }
+
+  if (selected.length === 0) return null;
+
+  const cards: LovelaceCardConfig[] = [];
+  if (!hideHeading) {
+    cards.push({
+      type: 'heading',
+      heading_style: 'title',
+      heading: localize('sections.agenda'),
+      icon: 'mdi:calendar',
+    });
+  }
+
+  // HA's built-in calendar card. initial_view 'listWeek' gives a compact upcoming-list
+  // appearance; for a single calendar, the card naturally shows just that one.
+  cards.push({
+    type: 'calendar',
+    entities: selected,
+    initial_view: 'listWeek',
+  });
+
+  return { type: 'grid', cards };
+}

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -18,7 +18,8 @@
     "areas": "Bereiche",
     "areas_other": "Weitere Bereiche",
     "weather": "Wetter",
-    "energy": "Energie"
+    "energy": "Energie",
+    "agenda": "Agenda"
   },
   "summary": {
     "lights_on_one": "Licht an",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -18,7 +18,8 @@
     "areas": "Areas",
     "areas_other": "Other Areas",
     "weather": "Weather",
-    "energy": "Energy"
+    "energy": "Energy",
+    "agenda": "Agenda"
   },
   "summary": {
     "lights_on_one": "light on",

--- a/src/types/strategy.ts
+++ b/src/types/strategy.ts
@@ -8,7 +8,7 @@
 
 // -- Section Ordering -------------------------------------------------
 
-export type SectionKey = 'overview' | 'custom_cards' | 'areas' | 'weather' | 'energy';
+export type SectionKey = 'overview' | 'custom_cards' | 'areas' | 'weather' | 'energy' | 'agenda';
 
 export const DEFAULT_SECTIONS_ORDER: SectionKey[] = [
   'overview',
@@ -16,6 +16,7 @@ export const DEFAULT_SECTIONS_ORDER: SectionKey[] = [
   'areas',
   'weather',
   'energy',
+  'agenda',
 ];
 
 // -- Main Strategy Config ---------------------------------------------
@@ -48,6 +49,8 @@ export interface Simon42StrategyConfig {
   show_switches_on_areas?: boolean; // default: false
   show_alerts_on_areas?: boolean; // default: false
   energy_link_dashboard?: boolean; // default: true
+  show_agenda_section?: boolean; // default: false (auto-hides when no calendars)
+  agenda_calendar_entities?: string[]; // default: [] → all visible calendars
 
   // Layout
   sections_order?: SectionKey[]; // default: DEFAULT_SECTIONS_ORDER

--- a/src/views/OverviewViewStrategy.ts
+++ b/src/views/OverviewViewStrategy.ts
@@ -17,6 +17,7 @@ import { createPersonBadges } from '../utils/badge-builder';
 import { createOverviewSection, createCustomCardsSection } from '../sections/OverviewSection';
 import { createAreasSection } from '../sections/AreasSection';
 import { createWeatherSection, createEnergySection } from '../sections/WeatherEnergySection';
+import { createAgendaSection } from '../sections/AgendaSection';
 import { createOverviewView } from '../utils/view-builder';
 import { timeStart, timeEnd, debugLog } from '../utils/debug';
 
@@ -25,7 +26,7 @@ import { timeStart, timeEnd, debugLog } from '../utils/debug';
  * appends any missing keys at the end (forward compatibility).
  */
 function normalizeSectionsOrder(order: SectionKey[]): SectionKey[] {
-  const validKeys = new Set<SectionKey>(['overview', 'custom_cards', 'areas', 'weather', 'energy']);
+  const validKeys = new Set<SectionKey>(['overview', 'custom_cards', 'areas', 'weather', 'energy', 'agenda']);
   const seen = new Set<SectionKey>();
   const result: SectionKey[] = [];
   for (const key of order) {
@@ -111,6 +112,11 @@ class Simon42ViewOverviewStrategy extends HTMLElement {
       ['areas', areasSections],
       ['weather', createWeatherSection(weatherEntity ?? null, showWeather)],
       ['energy', createEnergySection(showEnergy, dashboardConfig.energy_link_dashboard !== false)],
+      ['agenda', createAgendaSection(
+        hass,
+        dashboardConfig.show_agenda_section === true,
+        dashboardConfig.agenda_calendar_entities,
+      )],
     ]);
 
     // Assemble in configured order, appending assigned custom cards to each section


### PR DESCRIPTION
## Summary

Surfaces \`calendar.*\` entities on the overview via HA's built-in \`calendar\` card with \`initial_view: listWeek\` — a compact \"upcoming events\" list.

## Modular + auto-hide

- \`show_agenda_section\` defaults to \`false\` → no surface area change for existing users
- Even when toggled on, the section auto-hides when no \`calendar.*\` entities exist
- Optional \`agenda_calendar_entities\` config restricts the card to a chosen subset; unset → all visible calendars (no_dboard / hidden filtered)
- Section position via \`sections_order\` like every other section

## Test plan

- [x] Default → no section, no behaviour change
- [x] Toggle on with calendars → section appears with the calendar card
- [x] Toggle on without calendars → section auto-hidden
- [x] \`agenda_calendar_entities\` restricts to chosen entities, invalid ids dropped silently
- [x] TypeScript clean

---
_AI-drafted under human supervision by @TheDave94. Tested live on Home Assistant — fully when the relevant hardware is available, otherwise only along the code paths that don't require an actual sensor of that type._