### PR TITLE
feat(todos): optional To-do section using HA's built-in todo-list card

### DIFF
--- a/src/editor/StrategyEditor.ts
+++ b/src/editor/StrategyEditor.ts
@@ -1059,6 +1059,8 @@ class Simon42DashboardStrategyEditor extends LitElement {
         return this._config.show_weather === false;
       case 'energy':
         return this._config.show_energy === false;
+      case 'todos':
+        return this._config.show_todos_section !== true;
       default:
         return false;
     }
@@ -1070,10 +1072,11 @@ class Simon42DashboardStrategyEditor extends LitElement {
     ['areas', { icon: 'mdi:floor-plan', labelKey: 'sections.areas' }],
     ['weather', { icon: 'mdi:weather-partly-cloudy', labelKey: 'sections.weather' }],
     ['energy', { icon: 'mdi:lightning-bolt', labelKey: 'sections.energy' }],
+    ['todos', { icon: 'mdi:format-list-checks', labelKey: 'sections.todos' }],
   ]);
 
   private _isSectionToggleable(key: SectionKey): boolean {
-    return key === 'weather' || key === 'energy';
+    return key === 'weather' || key === 'energy' || key === 'todos';
   }
 
   private _toggleSectionVisibility(key: SectionKey, visible: boolean): void {
@@ -1081,6 +1084,8 @@ class Simon42DashboardStrategyEditor extends LitElement {
       this._toggleChanged('show_weather', visible, true);
     } else if (key === 'energy') {
       this._toggleChanged('show_energy', visible, true);
+    } else if (key === 'todos') {
+      this._toggleChanged('show_todos_section', visible, false);
     }
   }
 

--- a/src/sections/TodosSection.ts
+++ b/src/sections/TodosSection.ts
@@ -1,0 +1,65 @@
+// ====================================================================
+// Todos Section Builder
+// ====================================================================
+// Renders one HA-native `todo-list` card per selected todo.* entity.
+// Auto-hides when no todo entities exist or none are selected.
+// ====================================================================
+
+import type { HomeAssistant } from '../types/homeassistant';
+import type { LovelaceCardConfig, LovelaceSectionConfig } from '../types/lovelace';
+import { Registry } from '../Registry';
+import { localize } from '../utils/localize';
+
+/**
+ * Creates the todos section.
+ * Returns null when no todo.* entities exist or all configured ones are
+ * missing — modular auto-hide.
+ *
+ * @param hass HA state
+ * @param enabled toggle from config
+ * @param todoEntities optional explicit list (config). When empty/undefined,
+ *                     all visible todo.* entities are included.
+ * @param hideHeading suppress the section heading
+ */
+export function createTodosSection(
+  hass: HomeAssistant,
+  enabled: boolean,
+  todoEntities: string[] | undefined,
+  hideHeading: boolean = false
+): LovelaceSectionConfig | null {
+  if (!enabled) return null;
+
+  const visible = Registry.getVisibleEntityIdsForDomain('todo').filter(
+    (id) => hass.states[id] !== undefined
+  );
+
+  let selected: string[];
+  if (Array.isArray(todoEntities) && todoEntities.length > 0) {
+    selected = todoEntities.filter((id) => visible.includes(id));
+  } else {
+    selected = visible;
+  }
+
+  if (selected.length === 0) return null;
+
+  const cards: LovelaceCardConfig[] = [];
+  if (!hideHeading) {
+    cards.push({
+      type: 'heading',
+      heading_style: 'title',
+      heading: localize('sections.todos'),
+      icon: 'mdi:format-list-checks',
+    });
+  }
+
+  // One todo-list card per selected entity. HA's built-in todo-list card
+  // shows pending items inline with checkboxes and an add-item field.
+  for (const entityId of selected) {
+    cards.push({
+      type: 'todo-list',
+      entity: entityId,
+    });
+  }
+
+  return { type: 'grid', cards };
+}

--- a/src/sections/TodosSection.ts
+++ b/src/sections/TodosSection.ts
@@ -30,6 +30,7 @@ export function createTodosSection(
   if (!enabled) return null;
 
   const visible = Registry.getVisibleEntityIdsForDomain('todo').filter(
+    // eslint-disable-next-line security/detect-object-injection -- entity IDs from Registry
     (id) => hass.states[id] !== undefined
   );
 

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -18,7 +18,8 @@
     "areas": "Bereiche",
     "areas_other": "Weitere Bereiche",
     "weather": "Wetter",
-    "energy": "Energie"
+    "energy": "Energie",
+    "todos": "Aufgaben"
   },
   "summary": {
     "lights_on_one": "Licht an",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -18,7 +18,8 @@
     "areas": "Areas",
     "areas_other": "Other Areas",
     "weather": "Weather",
-    "energy": "Energy"
+    "energy": "Energy",
+    "todos": "To-do"
   },
   "summary": {
     "lights_on_one": "light on",

--- a/src/types/strategy.ts
+++ b/src/types/strategy.ts
@@ -8,7 +8,7 @@
 
 // -- Section Ordering -------------------------------------------------
 
-export type SectionKey = 'overview' | 'custom_cards' | 'areas' | 'weather' | 'energy';
+export type SectionKey = 'overview' | 'custom_cards' | 'areas' | 'weather' | 'energy' | 'todos';
 
 export const DEFAULT_SECTIONS_ORDER: SectionKey[] = [
   'overview',
@@ -16,6 +16,7 @@ export const DEFAULT_SECTIONS_ORDER: SectionKey[] = [
   'areas',
   'weather',
   'energy',
+  'todos',
 ];
 
 // -- Main Strategy Config ---------------------------------------------
@@ -48,6 +49,8 @@ export interface Simon42StrategyConfig {
   show_switches_on_areas?: boolean; // default: false
   show_alerts_on_areas?: boolean; // default: false
   energy_link_dashboard?: boolean; // default: true
+  show_todos_section?: boolean; // default: false (auto-hides when no todos)
+  todos_entities?: string[]; // default: [] → all visible todo.* entities
 
   // Layout
   sections_order?: SectionKey[]; // default: DEFAULT_SECTIONS_ORDER

--- a/src/views/OverviewViewStrategy.ts
+++ b/src/views/OverviewViewStrategy.ts
@@ -17,6 +17,7 @@ import { createPersonBadges } from '../utils/badge-builder';
 import { createOverviewSection, createCustomCardsSection } from '../sections/OverviewSection';
 import { createAreasSection } from '../sections/AreasSection';
 import { createWeatherSection, createEnergySection } from '../sections/WeatherEnergySection';
+import { createTodosSection } from '../sections/TodosSection';
 import { createOverviewView } from '../utils/view-builder';
 import { timeStart, timeEnd, debugLog } from '../utils/debug';
 
@@ -25,7 +26,7 @@ import { timeStart, timeEnd, debugLog } from '../utils/debug';
  * appends any missing keys at the end (forward compatibility).
  */
 function normalizeSectionsOrder(order: SectionKey[]): SectionKey[] {
-  const validKeys = new Set<SectionKey>(['overview', 'custom_cards', 'areas', 'weather', 'energy']);
+  const validKeys = new Set<SectionKey>(['overview', 'custom_cards', 'areas', 'weather', 'energy', 'todos']);
   const seen = new Set<SectionKey>();
   const result: SectionKey[] = [];
   for (const key of order) {
@@ -111,6 +112,7 @@ class Simon42ViewOverviewStrategy extends HTMLElement {
       ['areas', areasSections],
       ['weather', createWeatherSection(weatherEntity ?? null, showWeather)],
       ['energy', createEnergySection(showEnergy, dashboardConfig.energy_link_dashboard !== false)],
+      ['todos', createTodosSection(hass, dashboardConfig.show_todos_section === true, dashboardConfig.todos_entities)],
     ]);
 
     // Assemble in configured order, appending assigned custom cards to each section


### PR DESCRIPTION
## Summary

Surfaces \`todo.*\` entities on the overview using HA's native \`todo-list\` card — pending items inline, add-item field, checkboxes.

## Modular + auto-hide

- \`show_todos_section\` defaults to \`false\` → no surface area change
- Section auto-hides when no \`todo.*\` entities exist
- Optional \`todos_entities\` restricts to specific lists; unset → all visible

## Test plan

- [x] Default → no section
- [x] Toggle on with todo lists → one card per list
- [x] Toggle on without lists → auto-hidden
- [x] \`todos_entities\` filter respected, missing IDs dropped silently
- [x] TypeScript clean

---
_AI-drafted under human supervision by @TheDave94. Tested live on Home Assistant — fully when the relevant hardware is available, otherwise only along the code paths that don't require an actual sensor of that type._