### PR TITLE
feat(overview): optional unavailable-entities alert badge

### DIFF
--- a/src/editor/StrategyEditor.ts
+++ b/src/editor/StrategyEditor.ts
@@ -1134,6 +1134,13 @@ class Simon42DashboardStrategyEditor extends LitElement {
             `;
           })}
         </div>
+
+        <div style="margin-top: 12px;">
+          ${this._renderCheckbox('show-unavailable-alert-badge', localize('editor.show_unavailable_alert_badge'),
+            this._config.show_unavailable_alert_badge === true,
+            (checked) => this._toggleChanged('show_unavailable_alert_badge', checked, false))}
+          <div class="description">${localize('editor.show_unavailable_alert_badge_desc')}</div>
+        </div>
       </div>
     `;
   }

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -107,6 +107,8 @@
     "section_order_desc": "Ziehe die Abschnitte per Drag & Drop in die gewünschte Reihenfolge. Leere Abschnitte werden automatisch ausgeblendet.",
     "section_hidden": "ausgeblendet",
     "energy_link_dashboard": "Energie-Dashboard verlinken",
+    "show_unavailable_alert_badge": "Badge „Nicht verfügbare Entitäten“ anzeigen",
+    "show_unavailable_alert_badge_desc": "Fügt ein kleines rotes Badge in den Übersichts-Header ein, das die Anzahl der Entitäten mit Status „unavailable“ zeigt (kaputte Integration, leere Batterie, Offline-Gerät). Wird bei Null automatisch ausgeblendet. Respektiert das `no_dboard`-Label und pro-Entität Sichtbarkeits-Flags.",
     "target_section": "Zeige in",
     "section_overview": "Übersicht",
     "show_clock_card": "Uhrzeit-Karte anzeigen",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -107,6 +107,8 @@
     "section_order_desc": "Drag sections to reorder them on the overview page. Empty sections are hidden automatically.",
     "section_hidden": "hidden",
     "energy_link_dashboard": "Link to energy dashboard",
+    "show_unavailable_alert_badge": "Show \"unavailable entities\" alert badge",
+    "show_unavailable_alert_badge_desc": "Adds a small red badge to the overview header showing the count of entities whose state is \"unavailable\" (broken integration, dead battery, offline device). Auto-hidden when the count is zero. Respects the no_dboard label and per-entity hidden flags.",
     "target_section": "Show in",
     "section_overview": "Overview",
     "show_clock_card": "Show clock card",

--- a/src/types/strategy.ts
+++ b/src/types/strategy.ts
@@ -48,6 +48,7 @@ export interface Simon42StrategyConfig {
   show_switches_on_areas?: boolean; // default: false
   show_alerts_on_areas?: boolean; // default: false
   energy_link_dashboard?: boolean; // default: true
+  show_unavailable_alert_badge?: boolean; // default: false (auto-hides at zero)
 
   // Layout
   sections_order?: SectionKey[]; // default: DEFAULT_SECTIONS_ORDER

--- a/src/views/OverviewViewStrategy.ts
+++ b/src/views/OverviewViewStrategy.ts
@@ -149,7 +149,33 @@ class Simon42ViewOverviewStrategy extends HTMLElement {
       .filter((b) => b.parsed_config)
       .map((b) => b.parsed_config as LovelaceBadgeConfig);
 
-    return createOverviewView(overviewSections, [...personBadges, ...customBadges]);
+    // Optional "unavailable entities" alert badge — count entities whose
+    // state is "unavailable", skipping ones the user hid (no_dboard label,
+    // hidden_by, or hidden via Registry config). Auto-hide at zero.
+    const alertBadges: LovelaceBadgeConfig[] = [];
+    if (dashboardConfig.show_unavailable_alert_badge === true) {
+      let count = 0;
+      for (const [entityId, state] of Object.entries(hass.states)) {
+        if (state.state !== 'unavailable') continue;
+        if (Registry.isExcludedByLabel(entityId)) continue;
+        if (Registry.isHiddenByConfig(entityId)) continue;
+        const entry = Registry.getEntity(entityId);
+        if (entry?.hidden) continue;
+        count++;
+      }
+      if (count > 0 && someSensorId) {
+        alertBadges.push({
+          type: 'entity',
+          entity: someSensorId,
+          name: String(count),
+          icon: 'mdi:alert-circle-outline',
+          color: 'red',
+          show_state: false,
+        });
+      }
+    }
+
+    return createOverviewView(overviewSections, [...personBadges, ...alertBadges, ...customBadges]);
   }
 }
 


### PR DESCRIPTION
## Summary

Adds an optional red badge to the overview header showing the count of entities in the \`unavailable\` state. Helps users spot broken integrations, dead batteries, or offline devices at a glance without having to dig through the entity list.

## Modular + auto-hide

- \`show_unavailable_alert_badge\` defaults to **\`false\`** → no surface area change
- Badge **auto-hides at zero** (no badge shown when nothing is broken)
- Respects user-curated filters: \`no_dboard\` label, registry \`hidden\` flag, dashboard hidden config — entities the user already chose not to see don't inflate the count

## Required integration

**None.**

## Test plan

- [x] Default → no badge
- [x] Toggle on with 5 unavailable entities → badge shows \"5\" with alert-circle icon, red colour
- [x] Toggle on with 0 unavailable → badge hidden (no empty header item)
- [x] Hidden / no_dboard / config-filtered entities not counted
- [x] TypeScript clean

---
_AI-drafted under human supervision by @TheDave94. Tested live on Home Assistant — fully when the relevant hardware is available, otherwise only along the code paths that don't require an actual sensor of that type._