### PR TITLE
feat(overview): optional now-playing badge in the header

### DIFF
--- a/src/editor/StrategyEditor.ts
+++ b/src/editor/StrategyEditor.ts
@@ -1134,6 +1134,13 @@ class Simon42DashboardStrategyEditor extends LitElement {
             `;
           })}
         </div>
+
+        <div style="margin-top: 12px;">
+          ${this._renderCheckbox('show-now-playing-badge', localize('editor.show_now_playing_badge'),
+            this._config.show_now_playing_badge === true,
+            (checked) => this._toggleChanged('show_now_playing_badge', checked, false))}
+          <div class="description">${localize('editor.show_now_playing_badge_desc')}</div>
+        </div>
       </div>
     `;
   }

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -107,6 +107,8 @@
     "section_order_desc": "Ziehe die Abschnitte per Drag & Drop in die gewünschte Reihenfolge. Leere Abschnitte werden automatisch ausgeblendet.",
     "section_hidden": "ausgeblendet",
     "energy_link_dashboard": "Energie-Dashboard verlinken",
+    "show_now_playing_badge": "„Wird abgespielt“-Badge anzeigen",
+    "show_now_playing_badge_desc": "Fügt ein kleines grünes Badge in den Übersichts-Header ein, das den ersten Media-Player mit Status `playing` zeigt. Klick öffnet die Mediensteuerung. Wird automatisch ausgeblendet, wenn nichts läuft.",
     "target_section": "Zeige in",
     "section_overview": "Übersicht",
     "show_clock_card": "Uhrzeit-Karte anzeigen",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -107,6 +107,8 @@
     "section_order_desc": "Drag sections to reorder them on the overview page. Empty sections are hidden automatically.",
     "section_hidden": "hidden",
     "energy_link_dashboard": "Link to energy dashboard",
+    "show_now_playing_badge": "Show \"now playing\" badge",
+    "show_now_playing_badge_desc": "Adds a small green badge to the overview header showing the first media_player whose state is \"playing\". Click opens the media controls. Auto-hidden when nothing is playing.",
     "target_section": "Show in",
     "section_overview": "Overview",
     "show_clock_card": "Show clock card",

--- a/src/types/strategy.ts
+++ b/src/types/strategy.ts
@@ -48,6 +48,7 @@ export interface Simon42StrategyConfig {
   show_switches_on_areas?: boolean; // default: false
   show_alerts_on_areas?: boolean; // default: false
   energy_link_dashboard?: boolean; // default: true
+  show_now_playing_badge?: boolean; // default: false (auto-hides when nothing's playing)
 
   // Layout
   sections_order?: SectionKey[]; // default: DEFAULT_SECTIONS_ORDER

--- a/src/views/OverviewViewStrategy.ts
+++ b/src/views/OverviewViewStrategy.ts
@@ -149,7 +149,26 @@ class Simon42ViewOverviewStrategy extends HTMLElement {
       .filter((b) => b.parsed_config)
       .map((b) => b.parsed_config as LovelaceBadgeConfig);
 
-    return createOverviewView(overviewSections, [...personBadges, ...customBadges]);
+    // Optional "now playing" badge — first media_player in 'playing' state
+    const nowPlayingBadges: LovelaceBadgeConfig[] = [];
+    if (dashboardConfig.show_now_playing_badge === true) {
+      const playing = Registry.getVisibleEntityIdsForDomain('media_player').find((id) => {
+        // eslint-disable-next-line security/detect-object-injection -- entity IDs from Registry
+        return hass.states[id]?.state === 'playing';
+      });
+      if (playing) {
+        nowPlayingBadges.push({
+          type: 'entity',
+          entity: playing,
+          icon: 'mdi:play-circle',
+          color: 'green',
+          show_state: false,
+          tap_action: { action: 'more-info' },
+        });
+      }
+    }
+
+    return createOverviewView(overviewSections, [...personBadges, ...nowPlayingBadges, ...customBadges]);
   }
 }
 


### PR DESCRIPTION
## Summary

Adds an optional small green badge to the overview header showing the first \`media_player.*\` entity in the \`playing\` state. Tapping the badge opens the media-controls more-info dialog.

## Modular + auto-hide

- \`show_now_playing_badge\` defaults to **\`false\`** → no surface area change
- Badge renders **only** when a media_player is actively playing; auto-hides on paused / idle / off / unavailable

## Required integration

**None.** Uses HA-native \`media_player\` domain. Works with any media integration (Spotify, Apple TV, Chromecast, LG webOS, etc.).

## Test plan

- [x] Default → no badge
- [x] Toggle on, nothing playing → no badge
- [x] Toggle on, one playing → badge shows, tap opens more-info
- [x] Multiple playing → first match shown (deterministic via Registry order)
- [x] All paused → badge hides
- [x] TypeScript clean

---
_AI-drafted under human supervision by @TheDave94. Tested live on Home Assistant — fully when the relevant hardware is available, otherwise only along the code paths that don't require an actual sensor of that type._