### PR TITLE
feat(vacuums): new Vacuums & Mowers section

### DIFF
--- a/src/editor/StrategyEditor.ts
+++ b/src/editor/StrategyEditor.ts
@@ -1059,6 +1059,8 @@ class Simon42DashboardStrategyEditor extends LitElement {
         return this._config.show_weather === false;
       case 'energy':
         return this._config.show_energy === false;
+      case 'vacuums':
+        return this._config.show_vacuums_section !== true;
       default:
         return false;
     }
@@ -1070,10 +1072,11 @@ class Simon42DashboardStrategyEditor extends LitElement {
     ['areas', { icon: 'mdi:floor-plan', labelKey: 'sections.areas' }],
     ['weather', { icon: 'mdi:weather-partly-cloudy', labelKey: 'sections.weather' }],
     ['energy', { icon: 'mdi:lightning-bolt', labelKey: 'sections.energy' }],
+    ['vacuums', { icon: 'mdi:robot-vacuum', labelKey: 'sections.vacuums' }],
   ]);
 
   private _isSectionToggleable(key: SectionKey): boolean {
-    return key === 'weather' || key === 'energy';
+    return key === 'weather' || key === 'energy' || key === 'vacuums';
   }
 
   private _toggleSectionVisibility(key: SectionKey, visible: boolean): void {
@@ -1081,6 +1084,8 @@ class Simon42DashboardStrategyEditor extends LitElement {
       this._toggleChanged('show_weather', visible, true);
     } else if (key === 'energy') {
       this._toggleChanged('show_energy', visible, true);
+    } else if (key === 'vacuums') {
+      this._toggleChanged('show_vacuums_section', visible, false);
     }
   }
 

--- a/src/sections/VacuumsSection.ts
+++ b/src/sections/VacuumsSection.ts
@@ -1,0 +1,49 @@
+// ====================================================================
+// Vacuums Section Builder
+// ====================================================================
+// Renders vacuum.* and lawn_mower.* entities as tiles. Auto-hides when
+// none exist.
+// ====================================================================
+
+import type { HomeAssistant } from '../types/homeassistant';
+import type { LovelaceCardConfig, LovelaceSectionConfig } from '../types/lovelace';
+import { Registry } from '../Registry';
+import { localize } from '../utils/localize';
+
+export function createVacuumsSection(
+  hass: HomeAssistant,
+  enabled: boolean,
+  hideHeading: boolean = false
+): LovelaceSectionConfig | null {
+  if (!enabled) return null;
+
+  const vacuumIds = Registry.getVisibleEntityIdsForDomain('vacuum').filter(
+    (id) => hass.states[id] !== undefined
+  );
+  const mowerIds = Registry.getVisibleEntityIdsForDomain('lawn_mower').filter(
+    (id) => hass.states[id] !== undefined
+  );
+  const entities = [...vacuumIds, ...mowerIds];
+  if (entities.length === 0) return null;
+
+  const cards: LovelaceCardConfig[] = [];
+  if (!hideHeading) {
+    cards.push({
+      type: 'heading',
+      heading_style: 'title',
+      heading: localize('sections.vacuums'),
+      icon: 'mdi:robot-vacuum',
+    });
+  }
+
+  for (const entityId of entities) {
+    cards.push({
+      type: 'tile',
+      entity: entityId,
+      vertical: false,
+      state_content: ['state', 'last_changed'],
+    });
+  }
+
+  return { type: 'grid', cards };
+}

--- a/src/sections/VacuumsSection.ts
+++ b/src/sections/VacuumsSection.ts
@@ -18,9 +18,11 @@ export function createVacuumsSection(
   if (!enabled) return null;
 
   const vacuumIds = Registry.getVisibleEntityIdsForDomain('vacuum').filter(
+    // eslint-disable-next-line security/detect-object-injection -- entity IDs from Registry
     (id) => hass.states[id] !== undefined
   );
   const mowerIds = Registry.getVisibleEntityIdsForDomain('lawn_mower').filter(
+    // eslint-disable-next-line security/detect-object-injection -- entity IDs from Registry
     (id) => hass.states[id] !== undefined
   );
   const entities = [...vacuumIds, ...mowerIds];

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -18,7 +18,8 @@
     "areas": "Bereiche",
     "areas_other": "Weitere Bereiche",
     "weather": "Wetter",
-    "energy": "Energie"
+    "energy": "Energie",
+    "vacuums": "Saug- & Mähroboter"
   },
   "summary": {
     "lights_on_one": "Licht an",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -18,7 +18,8 @@
     "areas": "Areas",
     "areas_other": "Other Areas",
     "weather": "Weather",
-    "energy": "Energy"
+    "energy": "Energy",
+    "vacuums": "Vacuums & Mowers"
   },
   "summary": {
     "lights_on_one": "light on",

--- a/src/types/strategy.ts
+++ b/src/types/strategy.ts
@@ -8,7 +8,7 @@
 
 // -- Section Ordering -------------------------------------------------
 
-export type SectionKey = 'overview' | 'custom_cards' | 'areas' | 'weather' | 'energy';
+export type SectionKey = 'overview' | 'custom_cards' | 'areas' | 'weather' | 'energy' | 'vacuums';
 
 export const DEFAULT_SECTIONS_ORDER: SectionKey[] = [
   'overview',
@@ -16,6 +16,7 @@ export const DEFAULT_SECTIONS_ORDER: SectionKey[] = [
   'areas',
   'weather',
   'energy',
+  'vacuums',
 ];
 
 // -- Main Strategy Config ---------------------------------------------
@@ -48,6 +49,7 @@ export interface Simon42StrategyConfig {
   show_switches_on_areas?: boolean; // default: false
   show_alerts_on_areas?: boolean; // default: false
   energy_link_dashboard?: boolean; // default: true
+  show_vacuums_section?: boolean; // default: false (auto-hides without vacuum/mower)
 
   // Layout
   sections_order?: SectionKey[]; // default: DEFAULT_SECTIONS_ORDER

--- a/src/views/OverviewViewStrategy.ts
+++ b/src/views/OverviewViewStrategy.ts
@@ -17,6 +17,7 @@ import { createPersonBadges } from '../utils/badge-builder';
 import { createOverviewSection, createCustomCardsSection } from '../sections/OverviewSection';
 import { createAreasSection } from '../sections/AreasSection';
 import { createWeatherSection, createEnergySection } from '../sections/WeatherEnergySection';
+import { createVacuumsSection } from '../sections/VacuumsSection';
 import { createOverviewView } from '../utils/view-builder';
 import { timeStart, timeEnd, debugLog } from '../utils/debug';
 
@@ -25,7 +26,7 @@ import { timeStart, timeEnd, debugLog } from '../utils/debug';
  * appends any missing keys at the end (forward compatibility).
  */
 function normalizeSectionsOrder(order: SectionKey[]): SectionKey[] {
-  const validKeys = new Set<SectionKey>(['overview', 'custom_cards', 'areas', 'weather', 'energy']);
+  const validKeys = new Set<SectionKey>(['overview', 'custom_cards', 'areas', 'weather', 'energy', 'vacuums']);
   const seen = new Set<SectionKey>();
   const result: SectionKey[] = [];
   for (const key of order) {
@@ -111,6 +112,7 @@ class Simon42ViewOverviewStrategy extends HTMLElement {
       ['areas', areasSections],
       ['weather', createWeatherSection(weatherEntity ?? null, showWeather)],
       ['energy', createEnergySection(showEnergy, dashboardConfig.energy_link_dashboard !== false)],
+      ['vacuums', createVacuumsSection(hass, dashboardConfig.show_vacuums_section === true)],
     ]);
 
     // Assemble in configured order, appending assigned custom cards to each section


### PR DESCRIPTION
## Summary

Surfaces \`vacuum.*\` and \`lawn_mower.*\` entities (HA-native domains) as tiles in a dedicated section.

## Modular + auto-hide

- \`show_vacuums_section\` defaults to \`false\`
- Auto-hides when no vacuum or mower entities exist
- Section position via \`sections_order\`, toggleable in the editor

## Required integration

**None.** Works with any integration that exposes \`vacuum.*\` (Roborock, Roomba, Ecovacs, Xiaomi Vacuum…) or \`lawn_mower.*\` (Husqvarna Automower, Worx Landroid…).

---
_AI-drafted under human supervision by @TheDave94. Tested live on Home Assistant — fully when the relevant hardware is available, otherwise only along the code paths that don't require an actual sensor of that type._