### PR TITLE
feat(overview): optional sun badge

### DIFF
--- a/src/editor/StrategyEditor.ts
+++ b/src/editor/StrategyEditor.ts
@@ -1134,6 +1134,13 @@ class Simon42DashboardStrategyEditor extends LitElement {
             `;
           })}
         </div>
+
+        <div style="margin-top: 12px;">
+          ${this._renderCheckbox('show-sun-badge', localize('editor.show_sun_badge'),
+            this._config.show_sun_badge === true,
+            (checked) => this._toggleChanged('show_sun_badge', checked, false))}
+          <div class="description">${localize('editor.show_sun_badge_desc')}</div>
+        </div>
       </div>
     `;
   }

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -107,6 +107,8 @@
     "section_order_desc": "Ziehe die Abschnitte per Drag & Drop in die gewünschte Reihenfolge. Leere Abschnitte werden automatisch ausgeblendet.",
     "section_hidden": "ausgeblendet",
     "energy_link_dashboard": "Energie-Dashboard verlinken",
+    "show_sun_badge": "Sonnen-Badge (Sonnenauf-/-untergang)",
+    "show_sun_badge_desc": "Fügt ein kleines Badge in den Übersichts-Header ein, das zeigt, ob die Sonne aktuell auf- oder untergegangen ist. Klick öffnet die Details mit den nächsten Auf-/Untergangszeiten. Wird automatisch ausgeblendet, falls deine HA keine `sun.sun`-Entität hat (die eingebaute Sun-Integration ist in den meisten Installationen standardmäßig aktiv).",
     "target_section": "Zeige in",
     "section_overview": "Übersicht",
     "show_clock_card": "Uhrzeit-Karte anzeigen",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -107,6 +107,8 @@
     "section_order_desc": "Drag sections to reorder them on the overview page. Empty sections are hidden automatically.",
     "section_hidden": "hidden",
     "energy_link_dashboard": "Link to energy dashboard",
+    "show_sun_badge": "Show sun badge (sunrise/sunset)",
+    "show_sun_badge_desc": "Adds a small badge to the overview header that shows whether the sun is up, and links to the next sunrise/sunset time on tap. Auto-hidden if your HA has no sun.sun entity (the built-in sun integration is enabled by default in most installs).",
     "target_section": "Show in",
     "section_overview": "Overview",
     "show_clock_card": "Show clock card",

--- a/src/types/strategy.ts
+++ b/src/types/strategy.ts
@@ -48,6 +48,7 @@ export interface Simon42StrategyConfig {
   show_switches_on_areas?: boolean; // default: false
   show_alerts_on_areas?: boolean; // default: false
   energy_link_dashboard?: boolean; // default: true
+  show_sun_badge?: boolean; // default: false (requires HA sun integration / sun.sun entity)
 
   // Layout
   sections_order?: SectionKey[]; // default: DEFAULT_SECTIONS_ORDER

--- a/src/views/OverviewViewStrategy.ts
+++ b/src/views/OverviewViewStrategy.ts
@@ -149,7 +149,23 @@ class Simon42ViewOverviewStrategy extends HTMLElement {
       .filter((b) => b.parsed_config)
       .map((b) => b.parsed_config as LovelaceBadgeConfig);
 
-    return createOverviewView(overviewSections, [...personBadges, ...customBadges]);
+    // Optional sun badge — shows sun.sun with next sunrise/sunset
+    // (state_content auto-picks next_dawn/next_dusk from HA's sun integration).
+    // Auto-hide when no sun.sun entity present.
+    const sunBadges: LovelaceBadgeConfig[] = [];
+    if (dashboardConfig.show_sun_badge === true && hass.states['sun.sun']) {
+      const isAbove = hass.states['sun.sun'].state === 'above_horizon';
+      sunBadges.push({
+        type: 'entity',
+        entity: 'sun.sun',
+        name: '',
+        icon: isAbove ? 'mdi:weather-sunset-down' : 'mdi:weather-sunset-up',
+        color: isAbove ? 'amber' : 'indigo',
+        tap_action: { action: 'more-info' },
+      });
+    }
+
+    return createOverviewView(overviewSections, [...personBadges, ...sunBadges, ...customBadges]);
   }
 }
 


### PR DESCRIPTION
## Summary

Adds an optional badge that shows whether the sun is currently up or down, using HA's bundled \`sun.sun\` entity. Tap opens more-info with the next sunrise/sunset time.

## Modular + auto-hide

- \`show_sun_badge\` defaults to \`false\`
- Badge auto-hides when \`sun.sun\` isn't present

## Required integration

The HA-bundled \`sun\` integration (enabled by default in most installs — disable manually to skip).

---
_AI-drafted under human supervision by @TheDave94. Tested live on Home Assistant — fully when the relevant hardware is available, otherwise only along the code paths that don't require an actual sensor of that type._