### PR TITLE
feat(maintenance): new Pending Updates section

### DIFF
--- a/src/editor/StrategyEditor.ts
+++ b/src/editor/StrategyEditor.ts
@@ -1059,6 +1059,8 @@ class Simon42DashboardStrategyEditor extends LitElement {
         return this._config.show_weather === false;
       case 'energy':
         return this._config.show_energy === false;
+      case 'maintenance':
+        return this._config.show_maintenance_section !== true;
       default:
         return false;
     }
@@ -1070,10 +1072,11 @@ class Simon42DashboardStrategyEditor extends LitElement {
     ['areas', { icon: 'mdi:floor-plan', labelKey: 'sections.areas' }],
     ['weather', { icon: 'mdi:weather-partly-cloudy', labelKey: 'sections.weather' }],
     ['energy', { icon: 'mdi:lightning-bolt', labelKey: 'sections.energy' }],
+    ['maintenance', { icon: 'mdi:update', labelKey: 'sections.maintenance' }],
   ]);
 
   private _isSectionToggleable(key: SectionKey): boolean {
-    return key === 'weather' || key === 'energy';
+    return key === 'weather' || key === 'energy' || key === 'maintenance';
   }
 
   private _toggleSectionVisibility(key: SectionKey, visible: boolean): void {
@@ -1081,6 +1084,8 @@ class Simon42DashboardStrategyEditor extends LitElement {
       this._toggleChanged('show_weather', visible, true);
     } else if (key === 'energy') {
       this._toggleChanged('show_energy', visible, true);
+    } else if (key === 'maintenance') {
+      this._toggleChanged('show_maintenance_section', visible, false);
     }
   }
 

--- a/src/sections/MaintenanceSection.ts
+++ b/src/sections/MaintenanceSection.ts
@@ -1,0 +1,47 @@
+// ====================================================================
+// Maintenance Section Builder
+// ====================================================================
+// Surfaces update.* entities whose state is 'on' (i.e. a pending
+// update is available). Auto-hides when nothing's pending.
+// ====================================================================
+
+import type { HomeAssistant } from '../types/homeassistant';
+import type { LovelaceCardConfig, LovelaceSectionConfig } from '../types/lovelace';
+import { Registry } from '../Registry';
+import { localize } from '../utils/localize';
+
+export function createMaintenanceSection(
+  hass: HomeAssistant,
+  enabled: boolean,
+  hideHeading: boolean = false
+): LovelaceSectionConfig | null {
+  if (!enabled) return null;
+
+  const pending = Registry.getVisibleEntityIdsForDomain('update').filter((id) => {
+    // eslint-disable-next-line security/detect-object-injection -- entity IDs from Registry
+    return hass.states[id]?.state === 'on';
+  });
+  if (pending.length === 0) return null;
+
+  const cards: LovelaceCardConfig[] = [];
+  if (!hideHeading) {
+    cards.push({
+      type: 'heading',
+      heading_style: 'title',
+      heading: localize('sections.maintenance'),
+      icon: 'mdi:update',
+    });
+  }
+
+  for (const entityId of pending) {
+    cards.push({
+      type: 'tile',
+      entity: entityId,
+      vertical: false,
+      state_content: ['state', 'installed_version'],
+      color: 'orange',
+    });
+  }
+
+  return { type: 'grid', cards };
+}

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -18,7 +18,8 @@
     "areas": "Bereiche",
     "areas_other": "Weitere Bereiche",
     "weather": "Wetter",
-    "energy": "Energie"
+    "energy": "Energie",
+    "maintenance": "Anstehende Updates"
   },
   "summary": {
     "lights_on_one": "Licht an",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -18,7 +18,8 @@
     "areas": "Areas",
     "areas_other": "Other Areas",
     "weather": "Weather",
-    "energy": "Energy"
+    "energy": "Energy",
+    "maintenance": "Pending Updates"
   },
   "summary": {
     "lights_on_one": "light on",

--- a/src/types/strategy.ts
+++ b/src/types/strategy.ts
@@ -8,7 +8,7 @@
 
 // -- Section Ordering -------------------------------------------------
 
-export type SectionKey = 'overview' | 'custom_cards' | 'areas' | 'weather' | 'energy';
+export type SectionKey = 'overview' | 'custom_cards' | 'areas' | 'weather' | 'energy' | 'maintenance';
 
 export const DEFAULT_SECTIONS_ORDER: SectionKey[] = [
   'overview',
@@ -16,6 +16,7 @@ export const DEFAULT_SECTIONS_ORDER: SectionKey[] = [
   'areas',
   'weather',
   'energy',
+  'maintenance',
 ];
 
 // -- Main Strategy Config ---------------------------------------------
@@ -48,6 +49,7 @@ export interface Simon42StrategyConfig {
   show_switches_on_areas?: boolean; // default: false
   show_alerts_on_areas?: boolean; // default: false
   energy_link_dashboard?: boolean; // default: true
+  show_maintenance_section?: boolean; // default: false (auto-hides when nothing pending)
 
   // Layout
   sections_order?: SectionKey[]; // default: DEFAULT_SECTIONS_ORDER

--- a/src/views/OverviewViewStrategy.ts
+++ b/src/views/OverviewViewStrategy.ts
@@ -17,6 +17,7 @@ import { createPersonBadges } from '../utils/badge-builder';
 import { createOverviewSection, createCustomCardsSection } from '../sections/OverviewSection';
 import { createAreasSection } from '../sections/AreasSection';
 import { createWeatherSection, createEnergySection } from '../sections/WeatherEnergySection';
+import { createMaintenanceSection } from '../sections/MaintenanceSection';
 import { createOverviewView } from '../utils/view-builder';
 import { timeStart, timeEnd, debugLog } from '../utils/debug';
 
@@ -25,7 +26,7 @@ import { timeStart, timeEnd, debugLog } from '../utils/debug';
  * appends any missing keys at the end (forward compatibility).
  */
 function normalizeSectionsOrder(order: SectionKey[]): SectionKey[] {
-  const validKeys = new Set<SectionKey>(['overview', 'custom_cards', 'areas', 'weather', 'energy']);
+  const validKeys = new Set<SectionKey>(['overview', 'custom_cards', 'areas', 'weather', 'energy', 'maintenance']);
   const seen = new Set<SectionKey>();
   const result: SectionKey[] = [];
   for (const key of order) {
@@ -111,6 +112,7 @@ class Simon42ViewOverviewStrategy extends HTMLElement {
       ['areas', areasSections],
       ['weather', createWeatherSection(weatherEntity ?? null, showWeather)],
       ['energy', createEnergySection(showEnergy, dashboardConfig.energy_link_dashboard !== false)],
+      ['maintenance', createMaintenanceSection(hass, dashboardConfig.show_maintenance_section === true)],
     ]);
 
     // Assemble in configured order, appending assigned custom cards to each section


### PR DESCRIPTION
## Summary

Surfaces \`update.*\` entities whose state is \`on\` (pending update) as tiles in a dedicated *Pending Updates* section.

## Modular + auto-hide

- \`show_maintenance_section\` defaults to \`false\`
- Auto-hides when no updates are pending → users see the section only when there's something to action

## Required integration

**None** beyond HA itself. The \`update.*\` domain is HA-native; entities are published by HA core, HACS, add-ons, and various firmware-update integrations (e.g. ESPHome, Z-Wave devices that report firmware).

---
_AI-drafted under human supervision by @TheDave94. Tested live on Home Assistant — fully when the relevant hardware is available, otherwise only along the code paths that don't require an actual sensor of that type._