### PR TITLE
feat(rooms): hide unavailable entities in room views by default

### DIFF
--- a/src/editor/StrategyEditor.ts
+++ b/src/editor/StrategyEditor.ts
@@ -1455,6 +1455,11 @@ class Simon42DashboardStrategyEditor extends LitElement {
           (checked) => this._toggleChanged('show_scripts_in_rooms', checked, false))}
         <div class="description">${localize('editor.show_scripts_in_rooms_desc')}</div>
 
+        ${this._renderCheckbox('hide-unavailable-in-rooms', localize('editor.hide_unavailable_in_rooms'),
+          this._config.hide_unavailable_in_rooms !== false,
+          (checked) => this._toggleChanged('hide_unavailable_in_rooms', checked, true))}
+        <div class="description">${localize('editor.hide_unavailable_in_rooms_desc')}</div>
+
         ${this._renderCheckbox('use-default-area-sort', localize('editor.use_default_area_sort'), useDefaultAreaSort,
           (checked) => this._toggleChanged('use_default_area_sort', checked, false))}
         <div class="description">${localize('editor.use_default_area_sort_desc')}</div>

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -164,6 +164,8 @@
     "show_automations_in_rooms_desc": "Zeigt dem Bereich zugeordnete Automationen in den jeweiligen Raum-Ansichten an.",
     "show_scripts_in_rooms": "Skripte in Raum-Ansichten anzeigen",
     "show_scripts_in_rooms_desc": "Zeigt dem Bereich zugeordnete Skripte in den jeweiligen Raum-Ansichten an.",
+    "hide_unavailable_in_rooms": "Nicht verfügbare Entitäten in Raum-Ansichten ausblenden",
+    "hide_unavailable_in_rooms_desc": "Überspringt Entitäten mit Status `unavailable` (offline-Integrationen, leere Batterien, getrennte ESPHome-Geräte) beim Aufbau der Raum-Ansichten. Standardmäßig aktiv — diese Entitäten tauchen ohnehin in anderen Ansichten auf (Batterien-Ansicht, das optionale „Nicht verfügbar"-Badge) und sind in Raum-Ansichten meist nur Rauschen. Deaktivieren, um sie auch dort zu zeigen.",
     "show_window_contacts_in_rooms": "Fensterkontakte in Raum-Ansichten anzeigen",
     "show_window_contacts_in_rooms_desc": "Zeigt Fensterkontakte als Badges in den jeweiligen Raum-Ansichten an.",
     "show_door_contacts_in_rooms": "Türkontakte in Raum-Ansichten anzeigen",

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -165,7 +165,7 @@
     "show_scripts_in_rooms": "Skripte in Raum-Ansichten anzeigen",
     "show_scripts_in_rooms_desc": "Zeigt dem Bereich zugeordnete Skripte in den jeweiligen Raum-Ansichten an.",
     "hide_unavailable_in_rooms": "Nicht verfügbare Entitäten in Raum-Ansichten ausblenden",
-    "hide_unavailable_in_rooms_desc": "Überspringt Entitäten mit Status `unavailable` (offline-Integrationen, leere Batterien, getrennte ESPHome-Geräte) beim Aufbau der Raum-Ansichten. Standardmäßig aktiv — diese Entitäten tauchen ohnehin in anderen Ansichten auf (Batterien-Ansicht, das optionale „Nicht verfügbar"-Badge) und sind in Raum-Ansichten meist nur Rauschen. Deaktivieren, um sie auch dort zu zeigen.",
+    "hide_unavailable_in_rooms_desc": "Überspringt Entitäten mit Status `unavailable` (offline-Integrationen, leere Batterien, getrennte ESPHome-Geräte) beim Aufbau der Raum-Ansichten. Standardmäßig aktiv — diese Entitäten tauchen ohnehin in anderen Ansichten auf (Batterien-Ansicht, das optionale „Nicht verfügbar“-Badge) und sind in Raum-Ansichten meist nur Rauschen. Deaktivieren, um sie auch dort zu zeigen.",
     "show_window_contacts_in_rooms": "Fensterkontakte in Raum-Ansichten anzeigen",
     "show_window_contacts_in_rooms_desc": "Zeigt Fensterkontakte als Badges in den jeweiligen Raum-Ansichten an.",
     "show_door_contacts_in_rooms": "Türkontakte in Raum-Ansichten anzeigen",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -164,6 +164,8 @@
     "show_automations_in_rooms_desc": "Shows automations assigned to the area in the respective room views.",
     "show_scripts_in_rooms": "Show scripts in room views",
     "show_scripts_in_rooms_desc": "Shows scripts assigned to the area in the respective room views.",
+    "hide_unavailable_in_rooms": "Hide unavailable entities in room views",
+    "hide_unavailable_in_rooms_desc": "Skips entities whose state is `unavailable` (offline integrations, dead batteries, disconnected ESPHome devices) when building room views. Default on — these entities show up elsewhere (Batteries view, the optional Unavailable alert badge) and tend to be noise in a room view. Disable to surface them in the room view too.",
     "show_window_contacts_in_rooms": "Show window contacts in room views",
     "show_window_contacts_in_rooms_desc": "Shows window contacts as badges in the respective room views.",
     "show_door_contacts_in_rooms": "Show door contacts in room views",

--- a/src/types/strategy.ts
+++ b/src/types/strategy.ts
@@ -48,6 +48,7 @@ export interface Simon42StrategyConfig {
   show_switches_on_areas?: boolean; // default: false
   show_alerts_on_areas?: boolean; // default: false
   energy_link_dashboard?: boolean; // default: true
+  hide_unavailable_in_rooms?: boolean; // default: true (skip unavailable in room views)
 
   // Layout
   sections_order?: SectionKey[]; // default: DEFAULT_SECTIONS_ORDER

--- a/src/views/RoomViewStrategy.ts
+++ b/src/views/RoomViewStrategy.ts
@@ -84,12 +84,18 @@ class Simon42ViewRoomStrategy extends HTMLElement {
     // (no hidden, no_dboard, config/diagnostic, config-hidden)
     const visibleEntities = Registry.getVisibleEntitiesForArea(area.area_id);
 
+    // Filter unavailable entities from per-room domain lists / sensor badges.
+    // Default true: unavailable items are noise in a room view (offline devices,
+    // dead batteries surface elsewhere via the batteries view + alert badge).
+    const hideUnavailable = dashboardConfig.hide_unavailable_in_rooms !== false;
+
     for (const entity of visibleEntities) {
       const entityId = entity.entity_id;
 
       // State check
       const state = hass.states[entityId];
       if (!state) continue;
+      if (hideUnavailable && state.state === 'unavailable') continue;
 
       // Domain categorization
       const domain = entityId.split('.')[0];


### PR DESCRIPTION
## Summary

Adds \`hide_unavailable_in_rooms\` (default **\`true\`**) to skip entities with state \`unavailable\` when classifying room view entities + sensor badges. Cleans up the noise from offline integrations, intermittently-connected ESPHome devices, etc.

## Why default true

In practice no user benefits from seeing a tile that just reads \"Unavailable\" — the device is offline, the tile is non-functional. These entities are already surfaced elsewhere:

- **Batteries view** (with PR #248's user-controlled \`unavailable_batteries_bucket\`)
- The optional **\"Unavailable entities\" alert badge** (from one of the new badges in this batch)

So users still notice when something's broken; they just don't get an unactionable tile cluttering their room view.

## Behaviour change

Yes — existing dashboards with offline devices will see them disappear from room views once this lands. Disable the toggle to restore previous behaviour. Happy to flip to default \`false\` if you'd rather it be opt-in — let me know.

## Test plan

- [x] Default → unavailable entities skipped in room classifier
- [x] Disable → previous behaviour, unavailable tiles surface again
- [x] No effect on Batteries view (which has its own unavailable handling)
- [x] No effect on the Unavailable alert badge (which uses hass.states directly)
- [x] TypeScript clean

---
_AI-drafted under human supervision by @TheDave94. Tested live on Home Assistant — fully when the relevant hardware is available, otherwise only along the code paths that don't require an actual sensor of that type._