### PR TITLE
feat(overview): optional pending-updates count badge

### DIFF
--- a/src/editor/StrategyEditor.ts
+++ b/src/editor/StrategyEditor.ts
@@ -1134,6 +1134,13 @@ class Simon42DashboardStrategyEditor extends LitElement {
             `;
           })}
         </div>
+
+        <div style="margin-top: 12px;">
+          ${this._renderCheckbox('show-updates-badge', localize('editor.show_updates_badge'),
+            this._config.show_updates_badge === true,
+            (checked) => this._toggleChanged('show_updates_badge', checked, false))}
+          <div class="description">${localize('editor.show_updates_badge_desc')}</div>
+        </div>
       </div>
     `;
   }

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -107,6 +107,8 @@
     "section_order_desc": "Ziehe die Abschnitte per Drag & Drop in die gewünschte Reihenfolge. Leere Abschnitte werden automatisch ausgeblendet.",
     "section_hidden": "ausgeblendet",
     "energy_link_dashboard": "Energie-Dashboard verlinken",
+    "show_updates_badge": "Anstehende Updates als Badge anzeigen",
+    "show_updates_badge_desc": "Fügt ein kleines oranges Badge in den Übersichts-Header ein, das die Anzahl der `update.*`-Entitäten mit Status `on` (Update verfügbar) zeigt. Klick öffnet Einstellungen → Updates. Wird automatisch ausgeblendet, wenn keine Updates anstehen. Benötigte Integration: keine — die `update.*`-Domain ist HA-nativ.",
     "target_section": "Zeige in",
     "section_overview": "Übersicht",
     "show_clock_card": "Uhrzeit-Karte anzeigen",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -107,6 +107,8 @@
     "section_order_desc": "Drag sections to reorder them on the overview page. Empty sections are hidden automatically.",
     "section_hidden": "hidden",
     "energy_link_dashboard": "Link to energy dashboard",
+    "show_updates_badge": "Show pending updates count badge",
+    "show_updates_badge_desc": "Adds a small orange badge to the overview header showing the count of update.* entities in state \"on\" (pending). Tap navigates to Settings → Updates. Auto-hidden when no updates are pending. Required integration: none — the update.* domain is HA-native.",
     "target_section": "Show in",
     "section_overview": "Overview",
     "show_clock_card": "Show clock card",

--- a/src/types/strategy.ts
+++ b/src/types/strategy.ts
@@ -48,6 +48,7 @@ export interface Simon42StrategyConfig {
   show_switches_on_areas?: boolean; // default: false
   show_alerts_on_areas?: boolean; // default: false
   energy_link_dashboard?: boolean; // default: true
+  show_updates_badge?: boolean; // default: false (auto-hides at zero pending)
 
   // Layout
   sections_order?: SectionKey[]; // default: DEFAULT_SECTIONS_ORDER

--- a/src/views/OverviewViewStrategy.ts
+++ b/src/views/OverviewViewStrategy.ts
@@ -149,7 +149,32 @@ class Simon42ViewOverviewStrategy extends HTMLElement {
       .filter((b) => b.parsed_config)
       .map((b) => b.parsed_config as LovelaceBadgeConfig);
 
-    return createOverviewView(overviewSections, [...personBadges, ...customBadges]);
+    // Optional "pending updates count" badge — Registry-filtered update.* in state 'on'.
+    const updatesBadges: LovelaceBadgeConfig[] = [];
+    if (dashboardConfig.show_updates_badge === true) {
+      let count = 0;
+      let firstId: string | undefined;
+      for (const id of Registry.getVisibleEntityIdsForDomain('update')) {
+        const st = Reflect.get(hass.states as Record<string, unknown>, id) as { state?: string } | undefined;
+        if (st?.state === 'on') {
+          count++;
+          if (!firstId) firstId = id;
+        }
+      }
+      if (count > 0 && firstId) {
+        updatesBadges.push({
+          type: 'entity',
+          entity: firstId,
+          name: String(count),
+          icon: 'mdi:update',
+          color: 'orange',
+          show_state: false,
+          tap_action: { action: 'navigate', navigation_path: '/config/updates' },
+        });
+      }
+    }
+
+    return createOverviewView(overviewSections, [...personBadges, ...updatesBadges, ...customBadges]);
   }
 }
 


### PR DESCRIPTION
## Summary

Adds an optional small orange badge to the overview header showing the count of \`update.*\` entities in state \`on\`. Tap navigates to **Settings → Updates**.

## Modular + auto-hide

- \`show_updates_badge\` defaults to \`false\`
- Auto-hides at zero
- Companion to PR #260 (Pending Updates section) — use the badge for a glance, the section for inline tile details, or both

## Required integration

**None.** \`update.*\` is HA-native.

---
_AI-drafted under human supervision by @TheDave94. Tested live on Home Assistant — fully when the relevant hardware is available, otherwise only along the code paths that don't require an actual sensor of that type._