### PR TITLE
feat(rooms): per-room conditional visibility (entity-state gated)

### DIFF
--- a/src/editor/StrategyEditor.ts
+++ b/src/editor/StrategyEditor.ts
@@ -1466,8 +1466,59 @@ class Simon42DashboardStrategyEditor extends LitElement {
         <div class="area-list" id="area-list">
           ${this._renderAreaItems(allAreas, hiddenAreas, areaOrder)}
         </div>
+
+        <details style="margin-top: 12px;">
+          <summary style="cursor: pointer; font-size: 13px; font-weight: 500; color: var(--primary-text-color); padding: 4px 0;">
+            ${localize('editor.room_visibility')}
+          </summary>
+          <div style="margin-left: 14px; margin-top: 6px;">
+            <div class="description" style="margin-left: 0; margin-bottom: 8px;">
+              ${localize('editor.room_visibility_desc')}
+            </div>
+            ${allAreas.filter((a) => !hiddenAreas.includes(a.area_id)).map((area) => {
+              const rule = this._config.room_visibility?.[area.area_id];
+              return html`
+                <div style="border: 1px solid var(--divider-color); border-radius: 6px; padding: 8px; margin-bottom: 8px;">
+                  <div style="font-weight: 500; margin-bottom: 6px;">${area.name}</div>
+                  <div class="form-row">
+                    <label for="room-vis-entity-${area.area_id}" style="min-width: 80px; font-size: 12px;">${localize('editor.section_visibility_entity')}</label>
+                    <input type="text" id="room-vis-entity-${area.area_id}" style="flex: 1;"
+                      placeholder="input_boolean.guest_mode"
+                      .value=${rule?.entity || ''}
+                      @change=${(e: Event) => this._roomVisibilityChanged(area.area_id, 'entity', (e.target as HTMLInputElement).value)} />
+                  </div>
+                  <div class="form-row">
+                    <label for="room-vis-state-${area.area_id}" style="min-width: 80px; font-size: 12px;">${localize('editor.section_visibility_state')}</label>
+                    <input type="text" id="room-vis-state-${area.area_id}" style="flex: 1;"
+                      placeholder="on"
+                      .value=${rule?.state || ''}
+                      @change=${(e: Event) => this._roomVisibilityChanged(area.area_id, 'state', (e.target as HTMLInputElement).value)} />
+                  </div>
+                </div>
+              `;
+            })}
+          </div>
+        </details>
       </div>
     `;
+  }
+
+  private _roomVisibilityChanged(areaId: string, field: 'entity' | 'state', value: string): void {
+    const updated: Simon42StrategyConfig = { ...this._config };
+    const current = { ...(updated.room_visibility || {}) };
+    const rule = { ...(current[areaId] || { entity: '', state: '' }) };
+    rule[field] = value.trim();
+    if (!rule.entity && !rule.state) {
+      delete current[areaId];
+    } else {
+      current[areaId] = rule;
+    }
+    if (Object.keys(current).length === 0) {
+      delete updated.room_visibility;
+    } else {
+      updated.room_visibility = current;
+    }
+    this._fireConfigChanged(updated);
   }
 
   private _renderRoomPinsSection(): TemplateResult {

--- a/src/simon42-dashboard-strategy.ts
+++ b/src/simon42-dashboard-strategy.ts
@@ -53,7 +53,19 @@ class Simon42DashboardStrategy extends HTMLElement {
     Registry.initialize(hass, config);
     t('registry initialized');
 
-    const visibleAreas = getVisibleAreasFromHass(hass, config.areas_display, config.use_default_area_sort);
+    const allVisibleAreas = getVisibleAreasFromHass(hass, config.areas_display, config.use_default_area_sort);
+
+    // Per-room conditional visibility: filter the area list used to build
+    // room views / nav tabs. The overview's area cards section is NOT
+    // filtered — it uses Registry.areas via OverviewViewStrategy and the
+    // user can already hide individual area cards via areas_display.hidden.
+    const roomVisibility = config.room_visibility || {};
+    const visibleAreas = allVisibleAreas.filter((area) => {
+      const rule = Reflect.get(roomVisibility, area.area_id) as { entity?: string; state?: string } | undefined;
+      if (!rule?.entity) return true;
+      const st = Reflect.get(hass.states as Record<string, unknown>, rule.entity) as { state?: string } | undefined;
+      return !!st && st.state === rule.state;
+    });
 
     const showSummaryViews = config.show_summary_views === true;
     const showRoomViews = config.show_room_views === true;

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -171,6 +171,8 @@
     "use_default_area_sort": "Home Assistant Sortierung verwenden",
     "use_default_area_sort_desc": "Verwendet die Sortierung der Bereiche aus Home Assistant anstelle der hier konfigurierten Reihenfolge.",
     "areas_manage_desc": "Wähle aus, welche Bereiche im Dashboard angezeigt werden sollen und in welcher Reihenfolge. Klappe Bereiche auf, um einzelne Entitäten zu verwalten.",
+    "room_visibility": "Bedingte Raum-Sichtbarkeit",
+    "room_visibility_desc": "Blendet eine komplette Raum-Ansicht (und ihren Tab in der Navigation) aus, solange eine gewählte Entität nicht den angegebenen Status hat. Praktisch für Gäste-Modus-Räume (Entität: `input_boolean.guest_mode`, Status: `on`), Saison-Räume (z.B. Garten nur im Sommer) oder Räume, die nur relevant sind, wenn jemand zu Hause ist. Die Bereichs-Karten auf der Übersicht sind NICHT betroffen — nutze die Bereichs-Liste oben, um Karten dort auszublenden.",
     "section_room_pins": "Raum-Pins",
     "room_pins_desc": "Wähle Entitäten aus, die in ihren zugeordneten Räumen als erstes angezeigt werden sollen. Ideal für Entitäten die normalerweise nicht automatisch erfasst werden (z.B. Wetterstationen, spezielle Sensoren). <strong>Nur Entitäten mit Raum-Zuordnung können ausgewählt werden.</strong> Diese Pins erscheinen nur im jeweiligen Raum, nicht in der Übersicht.",
     "section_views": "Ansichten",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -171,6 +171,8 @@
     "use_default_area_sort": "Use Home Assistant sorting",
     "use_default_area_sort_desc": "Uses the area sorting from Home Assistant instead of the order configured here.",
     "areas_manage_desc": "Choose which areas should be shown on the dashboard and in what order. Expand areas to manage individual entities.",
+    "room_visibility": "Conditional room visibility",
+    "room_visibility_desc": "Optionally hide a whole room view (and its nav tab) unless a chosen entity is in a specific state. Useful for guest mode rooms (entity: input_boolean.guest_mode, state: on), seasonal rooms (e.g. garden in summer), or rooms that only apply when someone's home. The area cards on the overview are NOT affected — use the area-list above to hide cards there.",
     "section_room_pins": "Room Pins",
     "room_pins_desc": "Select entities to be shown first in their assigned rooms. Ideal for entities that are not automatically detected (e.g. weather stations, special sensors). <strong>Only entities with room assignment can be selected.</strong> These pins only appear in their respective room, not on the overview.",
     "section_views": "Views",

--- a/src/types/strategy.ts
+++ b/src/types/strategy.ts
@@ -48,6 +48,16 @@ export interface Simon42StrategyConfig {
   show_switches_on_areas?: boolean; // default: false
   show_alerts_on_areas?: boolean; // default: false
   energy_link_dashboard?: boolean; // default: true
+  /**
+   * Per-room conditional visibility. Keyed by area_id. When set, the room
+   * view (and its corresponding nav tab) is only rendered when
+   * hass.states[entity].state === state. Useful for guest-mode rooms,
+   * seasonal rooms (garden in winter), etc.
+   *
+   * The overview's area cards section is NOT affected — only the per-area
+   * room views and nav tabs.
+   */
+  room_visibility?: Record<string, { entity: string; state: string }>;
 
   // Layout
   sections_order?: SectionKey[]; // default: DEFAULT_SECTIONS_ORDER


### PR DESCRIPTION
## Summary

Sister to PR #263 (section_visibility on the overview). Adds **\`room_visibility\`**: each area can have a \`{ entity, state }\` rule that hides the room view + its nav tab until the entity matches the state.

## Example use cases

- Guest room visible only when \`input_boolean.guest_mode\` is on
- Garden room visible only in summer (template sensor)
- Office room visible only on workdays (\`calendar.workday_sensor\` = \`on\`)
- \"Away mode\" rooms when \`person.*\` is \`not_home\`

## Modular

- Empty default → no rooms gated
- Per-area: empty entity disables the rule
- Editor: collapsible *Conditional room visibility* panel under the area list
- The overview's area cards section is **NOT** filtered — use the existing area-list / \`areas_display.hidden\` for that

## Required integrations

**None** beyond whatever entity the user references.

## Test plan

- [x] Default → all rooms render (no change)
- [x] Rule on area X with state mismatching → room view + nav tab dropped
- [x] Rule matching → room view + nav tab present
- [x] Overview area cards unaffected when room views are gated
- [x] TypeScript clean

---
_AI-drafted under human supervision by @TheDave94. Tested live on Home Assistant — fully when the relevant hardware is available, otherwise only along the code paths that don't require an actual sensor of that type._