### PR TITLE
feat(overview): Quick Lights glance row (closes #176)

### DIFF
--- a/src/editor/StrategyEditor.ts
+++ b/src/editor/StrategyEditor.ts
@@ -72,6 +72,7 @@ class Simon42DashboardStrategyEditor extends LitElement {
   // Entity search state (NOT @state — we call requestUpdate manually)
   private _favoriteSearch = '';
   private _roomPinSearch = '';
+  private _lightFavSearch = '';
 
   // Cache for loaded area entities (avoid re-fetching on every render)
   private _areaEntitiesCache = new Map<string, {
@@ -1007,6 +1008,7 @@ class Simon42DashboardStrategyEditor extends LitElement {
         ${this._renderOverviewSection()}
         ${this._renderSummariesSection()}
         ${this._renderFavoritesSection()}
+        ${this._renderLightFavoritesSection()}
 
         <div class="section-divider">
           <div class="section-divider-title">
@@ -1339,6 +1341,74 @@ class Simon42DashboardStrategyEditor extends LitElement {
         </div>
       </div>
     `;
+  }
+
+  private _renderLightFavoritesSection(): TemplateResult {
+    const lightFavs = this._config.light_favorite_entities || [];
+    const allEntities = this._getAllEntitiesForSelect();
+    const entityMap = new Map(allEntities.map((e) => [e.entity_id, e.name]));
+    const filtered = this._getFilteredEntities(this._lightFavSearch).filter((e) => e.entity_id.startsWith('light.'));
+    return html`
+      <div class="section">
+        <div class="section-title">${localize('editor.section_light_favorites')}</div>
+
+        ${lightFavs.length > 0 ? html`
+          <div class="entity-list-container" style="margin-bottom: 8px;">
+            ${lightFavs.map((entityId) => {
+              const name = entityMap.get(entityId) || entityId;
+              return html`
+                <div class="entity-list-item" data-entity-id=${entityId}>
+                  <span class="item-info">
+                    <span class="item-name">${name}</span>
+                    <span class="item-entity-id">${entityId}</span>
+                  </span>
+                  <button class="btn-remove" @click=${() => this._removeLightFavorite(entityId)}>&#x2715;</button>
+                </div>
+              `;
+            })}
+          </div>
+        ` : nothing}
+
+        <div class="entity-search-picker">
+          <input type="text" class="entity-search-input"
+            placeholder=${localize('editor.select_entity') + '...'}
+            .value=${this._lightFavSearch}
+            @input=${(e: Event) => { this._lightFavSearch = (e.target as HTMLInputElement).value; this.requestUpdate(); }}
+            @blur=${() => { setTimeout(() => { this._lightFavSearch = ''; this.requestUpdate(); }, 200); }}
+          />
+          ${this._lightFavSearch.length >= 2 ? html`
+            <div class="entity-search-results">
+              ${filtered.length > 0
+                ? filtered.map((entity) => html`
+                  <div class="entity-search-result" @mousedown=${(e: Event) => { e.preventDefault(); this._addLightFavorite(entity.entity_id); this._lightFavSearch = ''; this.requestUpdate(); }}>
+                    <span class="entity-search-name">${entity.name}</span>
+                    <span class="entity-search-id">${entity.entity_id}</span>
+                  </div>
+                `)
+                : html`<div class="entity-search-no-results">${localize('editor.no_results')}</div>`
+              }
+            </div>
+          ` : nothing}
+        </div>
+        <div class="description">${localize('editor.light_favorites_desc')}</div>
+      </div>
+    `;
+  }
+
+  private _addLightFavorite(entityId: string): void {
+    const current = this._config.light_favorite_entities || [];
+    if (current.includes(entityId)) return;
+    const updated: Simon42StrategyConfig = { ...this._config, light_favorite_entities: [...current, entityId] };
+    this._fireConfigChanged(updated);
+  }
+
+  private _removeLightFavorite(entityId: string): void {
+    const current = this._config.light_favorite_entities || [];
+    const next = current.filter((e) => e !== entityId);
+    const updated: Simon42StrategyConfig = { ...this._config };
+    if (next.length === 0) delete updated.light_favorite_entities;
+    else updated.light_favorite_entities = next;
+    this._fireConfigChanged(updated);
   }
 
   private _renderFavoritesSection(): TemplateResult {

--- a/src/sections/OverviewSection.ts
+++ b/src/sections/OverviewSection.ts
@@ -169,7 +169,7 @@ export function createOverviewSection(data: OverviewSectionParams): LovelaceSect
 
   // Light favorites — quick toggle row using HA's native glance card
   const lightFavs = (config.light_favorite_entities || []).filter(
-    (id) => id.startsWith('light.') && hass.states[id] !== undefined
+    (id) => id.startsWith('light.') && Reflect.get(hass.states as Record<string, unknown>, id) !== undefined
   );
   if (lightFavs.length > 0) {
     cards.push({

--- a/src/sections/OverviewSection.ts
+++ b/src/sections/OverviewSection.ts
@@ -167,6 +167,31 @@ export function createOverviewSection(data: OverviewSectionParams): LovelaceSect
     }
   }
 
+  // Light favorites — quick toggle row using HA's native glance card
+  const lightFavs = (config.light_favorite_entities || []).filter(
+    (id) => id.startsWith('light.') && hass.states[id] !== undefined
+  );
+  if (lightFavs.length > 0) {
+    cards.push({
+      type: 'heading',
+      heading: localize('sections.light_favorites'),
+      icon: 'mdi:lightbulb-group',
+    });
+    cards.push({
+      type: 'glance',
+      show_name: true,
+      show_icon: true,
+      show_state: false,
+      columns: Math.min(lightFavs.length, 5),
+      entities: lightFavs.map((entityId) => ({
+        entity: entityId,
+        tap_action: { action: 'toggle' },
+        hold_action: { action: 'more-info' },
+      })),
+      grid_options: { columns: 'full' },
+    });
+  }
+
   // Favorites section
   const favoriteEntities = (config.favorite_entities || []).filter((entityId) => hass.states[entityId] !== undefined);
 

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -18,7 +18,8 @@
     "areas": "Bereiche",
     "areas_other": "Weitere Bereiche",
     "weather": "Wetter",
-    "energy": "Energie"
+    "energy": "Energie",
+    "light_favorites": "Schnellzugriff Lampen"
   },
   "summary": {
     "lights_on_one": "Licht an",
@@ -145,6 +146,8 @@
     "show_energy": "Energie-Dashboard anzeigen",
     "show_energy_desc": "Zeigt die Energie-Verteilungskarte in der Übersicht an, wenn Energiedaten verfügbar sind.",
     "section_favorites": "Favoriten",
+    "section_light_favorites": "Schnellzugriff Lampen",
+    "light_favorites_desc": "Lichter auswählen, die als kompakte Toggle-Reihe in der Übersicht (oberhalb der regulären Favoriten) erscheinen sollen. Jede Lampe wird als Glance-Icon gerendert: Tippen schaltet um, Lang-Drücken öffnet die Details. Wird automatisch ausgeblendet, wenn keine Lampe ausgewählt ist. Nur `light.*`-Entitäten können hinzugefügt werden.",
     "select_entity": "Entität auswählen...",
     "add": "+ Hinzufügen",
     "favorites_desc": "Wähle Entitäten aus, die als Favoriten unter den Zusammenfassungen angezeigt werden sollen. Die Entitäten werden als Kacheln angezeigt.",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -18,7 +18,8 @@
     "areas": "Areas",
     "areas_other": "Other Areas",
     "weather": "Weather",
-    "energy": "Energy"
+    "energy": "Energy",
+    "light_favorites": "Quick lights"
   },
   "summary": {
     "lights_on_one": "light on",
@@ -145,6 +146,8 @@
     "show_energy": "Show energy dashboard",
     "show_energy_desc": "Shows the energy distribution card on the overview when energy data is available.",
     "section_favorites": "Favorites",
+    "section_light_favorites": "Quick lights",
+    "light_favorites_desc": "Pick lights you want as a compact toggle row on the overview (above the regular favorites). Each light renders as a glance icon: tap to toggle on/off, long-press to open more-info. Auto-hidden when no light is selected. Only light.* entities can be added.",
     "select_entity": "Select entity...",
     "add": "+ Add",
     "favorites_desc": "Select entities to be shown as favorites below the summaries. Entities are displayed as tiles.",

--- a/src/types/strategy.ts
+++ b/src/types/strategy.ts
@@ -63,6 +63,7 @@ export interface Simon42StrategyConfig {
   alarm_entity?: string;
   favorite_entities?: string[];
   room_pin_entities?: string[];
+  light_favorite_entities?: string[]; // light.* glance row on overview (#176)
 
   // Area management
   use_default_area_sort?: boolean; // default: false


### PR DESCRIPTION
## Summary

Closes #176. Adds a **Quick Lights** row on the overview — a glance card with hand-picked lights for instant on/off control. Tap toggles, long-press opens more-info. Implementation mirrors the YAML pattern the issue author already uses, making it a one-click feature instead of manual custom-card config.

## Modular + auto-hide

- \`light_favorite_entities\` defaults to empty → no card
- Auto-hides when no \`light.*\` entities remain (non-light IDs and missing entities filtered)
- Editor: dedicated picker section under Favorites, type-ahead search restricted to \`light.*\` entities
- Glance card uses HA-native columns layout (up to 5 wide, auto-adapts for fewer)

## Required integration

**None.** \`light.*\` is HA-native.

## Test plan

- [x] Default empty → no card
- [x] Add a light → glance card appears
- [x] Tap → toggles light
- [x] Long-press → more-info opens
- [x] Remove all lights → card disappears, config key cleaned
- [x] Adding a non-light entity manually via YAML → filtered out at render
- [x] TypeScript clean

---
_AI-drafted under human supervision by @TheDave94. Tested live on Home Assistant — fully when the relevant hardware is available, otherwise only along the code paths that don't require an actual sensor of that type._