### PR TITLE
feat(editor): derive target_section dropdown from section meta map

### DIFF
--- a/src/editor/StrategyEditor.ts
+++ b/src/editor/StrategyEditor.ts
@@ -1744,9 +1744,9 @@ class Simon42DashboardStrategyEditor extends LitElement {
             <label>${localize('editor.target_section')}:</label>
             <select
               @change=${(e: Event) => this._updateCustomCardField(index, 'target_section', (e.target as HTMLSelectElement).value)}>
-              ${(['custom_cards', 'overview', 'areas', 'weather', 'energy'] as const).map((key) => html`
+              ${[...Simon42DashboardStrategyEditor._sectionMeta.entries()].map(([key, meta]) => html`
                 <option value=${key} ?selected=${(card.target_section || 'custom_cards') === key}>
-                  ${localize(Simon42DashboardStrategyEditor._sectionMeta.get(key)!.labelKey)}
+                  ${localize(meta.labelKey)}
                 </option>
               `)}
             </select>


### PR DESCRIPTION
## Summary

The custom-card editor's \`target_section\` dropdown was hardcoded to the five canonical sections:

\`\`\`ts
(['custom_cards', 'overview', 'areas', 'weather', 'energy'] as const).map(...)
\`\`\`

Switch it to derive options from \`_sectionMeta\` — the same \`Map<SectionKey, { icon, labelKey }>\` already used for the section-order panel.

## Why

If/when a new section type is added (plants, agenda, vacuums, todos, maintenance — any of the bundled PRs in #270, or future additions), the hardcoded list silently excludes it. Users wanting to target a custom card at a new section have to hand-edit YAML, which violates the editor-driven principle.

After this change, **any section registered in \`_sectionMeta\` automatically appears** in the dropdown. Single source of truth.

## Test plan

- [ ] Existing dashboards unchanged — the dropdown still shows the same five sections in the same order
- [ ] When PRs that add new sections to \`_sectionMeta\` land, those sections appear in this dropdown without further editor changes

---

AI-drafted under human supervision by @TheDave94. Tested live on Home Assistant — fully when the relevant hardware is available, otherwise only along the code paths that don't require an actual sensor of that type.