### PR TITLE
feat(editor): wire up show_window_contacts_in_rooms + show_door_contacts_in_rooms

### DIFF
--- a/src/editor/StrategyEditor.ts
+++ b/src/editor/StrategyEditor.ts
@@ -1421,6 +1421,9 @@ class Simon42DashboardStrategyEditor extends LitElement {
     const showLocksInRooms = this._config.show_locks_in_rooms === true;
     const showAutomationsInRooms = this._config.show_automations_in_rooms === true;
     const showScriptsInRooms = this._config.show_scripts_in_rooms === true;
+    // Window / door contact badges default to visible — read as opt-out (!== false).
+    const showWindowContactsInRooms = this._config.show_window_contacts_in_rooms !== false;
+    const showDoorContactsInRooms = this._config.show_door_contacts_in_rooms !== false;
     const useDefaultAreaSort = this._config.use_default_area_sort === true;
 
     const allAreas = Object.values(this._hass!.areas).sort((a, b) => a.name.localeCompare(b.name));
@@ -1454,6 +1457,14 @@ class Simon42DashboardStrategyEditor extends LitElement {
         ${this._renderCheckbox('show-scripts-in-rooms', localize('editor.show_scripts_in_rooms'), showScriptsInRooms,
           (checked) => this._toggleChanged('show_scripts_in_rooms', checked, false))}
         <div class="description">${localize('editor.show_scripts_in_rooms_desc')}</div>
+
+        ${this._renderCheckbox('show-window-contacts-in-rooms', localize('editor.show_window_contacts_in_rooms'), showWindowContactsInRooms,
+          (checked) => this._toggleChanged('show_window_contacts_in_rooms', checked, true))}
+        <div class="description">${localize('editor.show_window_contacts_in_rooms_desc')}</div>
+
+        ${this._renderCheckbox('show-door-contacts-in-rooms', localize('editor.show_door_contacts_in_rooms'), showDoorContactsInRooms,
+          (checked) => this._toggleChanged('show_door_contacts_in_rooms', checked, true))}
+        <div class="description">${localize('editor.show_door_contacts_in_rooms_desc')}</div>
 
         ${this._renderCheckbox('use-default-area-sort', localize('editor.use_default_area_sort'), useDefaultAreaSort,
           (checked) => this._toggleChanged('use_default_area_sort', checked, false))}

--- a/src/types/strategy.ts
+++ b/src/types/strategy.ts
@@ -43,8 +43,8 @@ export interface Simon42StrategyConfig {
   show_locks_in_rooms?: boolean; // default: false
   show_automations_in_rooms?: boolean; // default: false
   show_scripts_in_rooms?: boolean; // default: false
-  show_window_contacts_in_rooms?: boolean; // default: false
-  show_door_contacts_in_rooms?: boolean; // default: false
+  show_window_contacts_in_rooms?: boolean; // default: true (opt-out — set false to hide window contact badges)
+  show_door_contacts_in_rooms?: boolean; // default: true (opt-out — set false to hide door contact badges)
   show_switches_on_areas?: boolean; // default: false
   show_alerts_on_areas?: boolean; // default: false
   energy_link_dashboard?: boolean; // default: true

--- a/src/views/RoomViewStrategy.ts
+++ b/src/views/RoomViewStrategy.ts
@@ -295,8 +295,14 @@ class Simon42ViewRoomStrategy extends HTMLElement {
     }
 
     // Window/door: show ALL matches (not just first), users control via per-area hidden[]
-    for (const id of sensorEntities.window) addCandidate(id, 'window', 'window');
-    for (const id of sensorEntities.door) addCandidate(id, 'door', 'door');
+    // Per-domain opt-out via show_window_contacts_in_rooms / show_door_contacts_in_rooms
+    // (default true — preserves prior behavior; set false to silence the badge type).
+    if (dashboardConfig.show_window_contacts_in_rooms !== false) {
+      for (const id of sensorEntities.window) addCandidate(id, 'window', 'window');
+    }
+    if (dashboardConfig.show_door_contacts_in_rooms !== false) {
+      for (const id of sensorEntities.door) addCandidate(id, 'door', 'door');
+    }
 
     // Apply per-area badge config: filter hidden, append additional
     let filteredCandidates = candidates;


### PR DESCRIPTION
## Summary

Two config fields — \`show_window_contacts_in_rooms\` and \`show_door_contacts_in_rooms\` — existed in \`Simon42StrategyConfig\` with translation strings (en + de) describing intended behavior, but the implementation was never finished: **no editor UI and no view-side gating**. Changing the values in YAML had zero effect. From the user's perspective the feature was advertised in the strings but didn't work.

This PR closes that loop:

1. **\`RoomViewStrategy\`** now gates the window/door contact badge candidates on the corresponding flag. Default is **\`true\`** (opt-out via \`!== false\`), so existing installs see no behavior change — badges remain visible by default. Set either flag to \`false\` to silence that badge type.
2. **\`StrategyEditor\`** exposes both toggles in the Areas/Rooms section, alongside the existing \`show_locks_in_rooms\` / \`show_automations_in_rooms\` / \`show_scripts_in_rooms\` toggles.
3. **Type comments** updated to document the default-true / opt-out semantics (the original \`default: false\` comments were aspirational and would have been a breaking change had they been wired up that way).

## How this was found

Walked every field in \`Simon42StrategyConfig\` and grepped \`StrategyEditor.ts\` for each. After filtering out internal/derived types (FloorGroup, SensorEntities, ResolvedArea, LovelaceViewConfig fields like \`max_columns\`), these two were the only real \"declared in config but not wired anywhere\" gaps. The audit found no other YAML-only fields — every other config option already has editor UI.

## Test plan

- [ ] Defaults: existing dashboards unchanged (window + door badges still visible)
- [ ] Editor: both toggles appear in the Areas/Rooms section
- [ ] Toggle \`show_window_contacts_in_rooms\` off → window contact badges disappear
- [ ] Toggle \`show_door_contacts_in_rooms\` off → door contact badges disappear
- [ ] Both on → behaves identically to defaults

---

AI-drafted under human supervision by @TheDave94. Tested live on Home Assistant — fully when the relevant hardware is available, otherwise only along the code paths that don't require an actual sensor of that type.