### PR TITLE
chore(ci): release-please + release-build + ESLint enforcement

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,0 +1,66 @@
+name: Release Build
+
+# Triggered when release-please publishes a new GitHub Release.
+# Builds dist/ from source at the tagged commit, zips it, and attaches
+# the zip as a release asset. HACS picks up the zip via hacs.json's
+# `zip_release: true` flag.
+#
+# Separates concerns from release-please: that workflow owns versioning
+# + changelog + tagging; this one owns producing the artifact users
+# install. Either can be retried independently.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build (e.g. v1.4.0). Defaults to the latest release.'
+        required: false
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build + attach dist zip
+    runs-on: ubuntu-latest
+    steps:
+      - name: Determine ref
+        id: ref
+        run: |
+          if [ -n "${{ github.event.inputs.tag }}" ]; then
+            echo "ref=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.ref.outputs.ref }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Package dist into a zip
+        run: |
+          cd dist
+          zip -r ../simon42-dashboard-strategy.zip .
+          cd ..
+          ls -la simon42-dashboard-strategy.zip
+
+      - name: Attach zip to the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ steps.ref.outputs.ref }}" \
+            simon42-dashboard-strategy.zip \
+            --clobber

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,34 @@
+name: Release Please
+
+# Manages version bumps + changelog + tags via conventional commits.
+#
+# How it works:
+# 1. On every push to main, this workflow checks the commits since the last
+#    release. If any commits follow Conventional Commits format (feat:, fix:,
+#    feat!: etc.), it maintains a permanent "Release PR" that:
+#      - bumps package.json's version (patch / minor / major based on commits)
+#      - updates CHANGELOG.md
+# 2. When the maintainer merges that PR, release-please creates a git tag
+#    and a GitHub Release with the changelog as the body.
+# 3. The release event triggers .github/workflows/release-build.yml, which
+#    builds dist/ and attaches a zip as a release asset for HACS.
+#
+# The maintainer's job is simply to merge the Release PR when ready —
+# no manual version bumps, no manual changelog edits, no manual tagging.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          release-type: node

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -18,3 +18,16 @@ jobs:
       - uses: hacs/action@main
         with:
           category: plugin
+
+  lint:
+    name: ESLint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - name: Run ESLint
+        run: npm run lint


### PR DESCRIPTION
## Summary

Three small CI additions, all independent of each other:

### 1. \`release-please.yml\` — automated version + changelog

[googleapis/release-please-action](https://github.com/googleapis/release-please-action) maintains a permanent **\"Release PR\"** on main that:
- bumps \`package.json\`'s version based on conventional commits since the last release (\`fix:\` → patch, \`feat:\` → minor, \`feat!:\` / \`BREAKING CHANGE:\` → major)
- updates \`CHANGELOG.md\` with the grouped commits

When you merge that PR, release-please creates the git tag and a GitHub Release with the changelog as the body. **No more manual version bumps or hand-written changelogs.**

Your existing commit style (the grouped PRs all use \`feat:\`/\`fix:\`/\`chore:\` prefixes) is already conventional-commits-compatible, so this works out of the box.

### 2. \`release-build.yml\` — build dist on release

Listens for \`release.published\`, checks out the tag, runs \`npm ci && npm run build\`, zips \`dist/\`, and attaches the zip as \`simon42-dashboard-strategy.zip\` to the GitHub Release. Also has a \`workflow_dispatch\` trigger so a broken build can be re-run without re-tagging.

**Scope note**: this PR doesn't switch \`hacs.json\` to \`zip_release: true\` — HACS continues to read \`dist/\` from the repo at the tag (you keep committing dist/ manually before merging release PRs, same as today). The attached zip is a download-convenience artifact. A follow-up could flip \`hacs.json\` to make the zip the source of truth and eliminate the manual dist commit entirely; left out here to keep the change backward-compatible.

### 3. \`validate.yml\` — ESLint job

Adds a \`lint\` job that runs \`npm run lint\` (ESLint over \`src/**/*.ts\`). Catches the same class of issues Codacy does, runs deterministically on every PR, no noisy third-party-rule false positives.

Verified: ESLint on current upstream/main source is clean (0 errors, 1 warning) — this job will pass immediately on merge.

## Test plan

- [ ] release-please workflow file syntactically valid (lint when merged)
- [ ] After merge: release-please opens its first Release PR within minutes of the next push to main
- [ ] After merging a Release PR: tag + GH Release appear; release-build job runs; zip asset attached
- [ ] \`lint\` job runs on each PR and blocks merge when ESLint reports errors

---

AI-drafted under human supervision by @TheDave94. Tested live on Home Assistant — fully when the relevant hardware is available, otherwise only along the code paths that don't require an actual sensor of that type.