### PR TITLE
chore: Claude GitHub Action Workflows (Issue-Triage, @claude-Mention, PR-Review)

### DIFF
--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -1,0 +1,47 @@
+name: Claude Issue Triage
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            ISSUE NUMBER: ${{ github.event.issue.number }}
+            TITLE: ${{ github.event.issue.title }}
+            AUTHOR: ${{ github.event.issue.user.login }}
+
+            Triagiere dieses neue Issue für ein Home Assistant Dashboard-
+            Strategy-Projekt (deutschsprachige Community, viele Issues auf
+            Deutsch):
+
+            1. Kategorie bestimmen: Bug / Feature-Request / Frage-Support.
+               Passendes Label setzen (`gh label list` zeigt verfügbare;
+               fehlt ein passendes, nur kommentieren statt labeln).
+            2. Duplikat-Check: Mit `gh search issues` und `gh issue list`
+               nach ähnlichen offenen Issues suchen. Bei Duplikat: freundlich
+               auf Deutsch kommentieren, Original verlinken.
+            3. Bei Bugs: Prüfen, ob Version, HA-Version und Repro-Schritte
+               genannt sind. Fehlt das, freundlich auf Deutsch nachfragen
+               (STRATEGY_VERSION steht in der Browser-Konsole).
+            4. Bei Fragen: Wenn die Antwort klar aus README/CLAUDE.md
+               hervorgeht, direkt beantworten.
+
+            Ton: hilfsbereit, per Du, wie in der simon42-Community üblich.
+            Keine Zusagen machen, ob/wann ein Feature kommt.
+
+          claude_args: |
+            --allowedTools "Read,Glob,Grep,Bash(gh issue:*),Bash(gh search:*),Bash(gh label:*)"

--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -1,0 +1,37 @@
+name: Claude Mention
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    # Nur reagieren, wenn @claude erwähnt wird (bzw. Issue Claude zugewiesen wird)
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && github.event.assignee.login == 'claude')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Kein prompt → Action erkennt den Kontext selbst und reagiert
+          # auf die @claude-Erwähnung. Antworte-Sprache folgt dem Kommentar.
+          claude_args: |
+            --allowedTools "Read,Glob,Grep,Edit,Write,Bash(git:*),Bash(gh:*),Bash(npm run build:*),Bash(npm run lint:*),Bash(npm ci)"

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -41,9 +41,10 @@ jobs:
                Custom Cards nicht aufweichen, keine ungefilterten Entity-Scans
                in Cards, Chunk-Architektur nicht verändern, keine
                Auto-Detection für Temperatur/Feuchte auf Area Cards.
-            3. dist/: Wurde dist/ mitgeliefert und passt es zum Quellcode?
-               (Solange dist/ im Repo liegt, muss es aktuell sein.)
-               dist/-Diffs inhaltlich ignorieren, nur Konsistenz prüfen.
+            3. dist/: Das Repo enthält KEIN dist/ mehr (Auslieferung über
+               Release-Assets, siehe CLAUDE.md "Release Automation"). Enthält
+               der PR dist/-Dateien, freundlich bitten, sie zu entfernen —
+               Quellcode reicht.
             4. i18n: Neue UI-Strings müssen über die localize-Utility laufen
                und in de.json UND en.json vorhanden sein.
             5. Übliche Code-Qualität, Bugs, Typsicherheit (strict mode).

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,0 +1,60 @@
+name: Claude PR Review
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+jobs:
+  review:
+    # Draft-PRs überspringen
+    if: '!github.event.pull_request.draft'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          track_progress: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Du reviewst einen Community-PR für eine Home Assistant Lovelace
+            Dashboard Strategy (TypeScript, LitElement, Webpack code-splitting).
+            Lies zuerst die CLAUDE.md im Repo-Root — sie enthält Architektur,
+            Design-Entscheidungen und Complexity Hotspots.
+
+            Review-Schwerpunkte (in dieser Reihenfolge):
+
+            1. KREUZAUSWIRKUNGEN: Berührt der PR einen Complexity Hotspot
+               (Registry.ts, editor/StrategyEditor.ts, views/RoomViewStrategy.ts,
+               utils/name-utils.ts)? Wenn ja: Welche anderen Views/Cards
+               konsumieren die geänderten Funktionen/Maps? Explizit auflisten.
+            2. PERFORMANCE-PATTERNS: Verstößt der PR gegen dokumentierte
+               Design-Entscheidungen? Insbesondere: willUpdate()-Pattern der
+               Custom Cards nicht aufweichen, keine ungefilterten Entity-Scans
+               in Cards, Chunk-Architektur nicht verändern, keine
+               Auto-Detection für Temperatur/Feuchte auf Area Cards.
+            3. dist/: Wurde dist/ mitgeliefert und passt es zum Quellcode?
+               (Solange dist/ im Repo liegt, muss es aktuell sein.)
+               dist/-Diffs inhaltlich ignorieren, nur Konsistenz prüfen.
+            4. i18n: Neue UI-Strings müssen über die localize-Utility laufen
+               und in de.json UND en.json vorhanden sein.
+            5. Übliche Code-Qualität, Bugs, Typsicherheit (strict mode).
+
+            Abschluss-Kommentar auf Deutsch, freundlich (Community-Projekt!),
+            mit klarem Fazit: MERGEBAR / MERGEBAR NACH ÄNDERUNGEN / PORTEN
+            EMPFOHLEN (wenn Basis zu alt) / ABLEHNEN. Wenn der PR Issues
+            adressiert, die Nummern nennen.
+
+            Nutze `gh pr comment` für das Gesamtfazit und Inline-Kommentare
+            (mit confirmed: true) für konkrete Code-Stellen.
+
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh issue view:*)"


### PR DESCRIPTION
## Was ist drin

Drei GitHub-Actions-Workflows für die Claude Code Action (`anthropics/claude-code-action@v1`):

| Workflow | Trigger | Zweck |
|---|---|---|
| `claude-issue-triage.yml` | Issue geöffnet | Kategorisiert/labelt neue Issues, Duplikat-Check, fragt bei Bugs nach Repro-Infos (auf Deutsch, per Du) |
| `claude-mention.yml` | `@claude` in Kommentaren / Issue-Zuweisung | Reagiert auf Erwähnungen, kann Änderungen bauen und committen |
| `claude-pr-review.yml` | PR geöffnet/aktualisiert | Automatisches Review mit Fokus auf Kreuzauswirkungen, Performance-Patterns, dist/-Konsistenz und i18n |

## Voraussetzungen vor dem Merge

- [x] Claude GitHub App für das Repo installiert (https://github.com/apps/claude)
- [ ] Secret gesetzt: `ANTHROPIC_API_KEY` **oder** `CLAUDE_CODE_OAUTH_TOKEN` (dann werden die drei `anthropic_api_key`-Zeilen vor dem Merge auf `claude_code_oauth_token` umgestellt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)