### PR TITLE
chore: Version 1.3.5-beta.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simon42-dashboard-strategy",
-  "version": "1.3.4-beta.9",
+  "version": "1.3.5-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simon42-dashboard-strategy",
-      "version": "1.3.4-beta.9",
+      "version": "1.3.5-beta.1",
       "dependencies": {
         "js-yaml": "^4.1.0",
         "lit": "^3.3.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simon42-dashboard-strategy",
-  "version": "1.3.4-beta.9",
+  "version": "1.3.5-beta.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/simon42-dashboard-strategy.ts
+++ b/src/simon42-dashboard-strategy.ts
@@ -10,7 +10,7 @@ import type { HomeAssistant } from './types/homeassistant';
 import type { Simon42StrategyConfig } from './types/strategy';
 import type { LovelaceConfig, LovelaceViewConfig } from './types/lovelace';
 
-const STRATEGY_VERSION = '1.3.4-beta.9';
+const STRATEGY_VERSION = '1.3.5-beta.1';
 
 const DEBUG = new URLSearchParams(window.location.search).has('s42_debug');
 const T0 = performance.now();


### PR DESCRIPTION
Versions-Bump für das erste Release im neuen CI/CD-Modus (Release-Assets statt dist/ im Repo, #303). Nach dem Merge wird der Tag `v1.3.5-beta.1` gepusht → CI published das Pre-Release mit Assets → Beta-Test im Test-System via HACS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)