### PR TITLE
fix(ci): hacs/action entfernen — validiert nur den Branch-Baum, kann ohne dist/ nie grün werden

### DIFF
--- a/.github/workflows/release-prerelease.yml
+++ b/.github/workflows/release-prerelease.yml
@@ -37,7 +37,3 @@ jobs:
             dist/*.js.gz
             dist/*.js.br
             dist/*.js.LICENSE.txt
-      - name: Validate for HACS
-        uses: hacs/action@main
-        with:
-          category: plugin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,3 @@ jobs:
             dist/*.js.gz
             dist/*.js.br
             dist/*.js.LICENSE.txt
-      - name: Validate for HACS
-        uses: hacs/action@main
-        with:
-          category: plugin

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,15 +10,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  hacs:
-    name: HACS Validation
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: hacs/action@main
-        with:
-          category: plugin
-
   translations:
     name: Translation Lint
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,7 +167,7 @@ npm run watch       # Dev + auto-rebuild on file changes
 2. Develop, build, test on live system
 3. **Source only — `dist/` is gitignored and never committed.** HACS serves the built files as release assets (see Release Automation below); old tags (≤ v1.3.4-beta.9) still carry their committed `dist/`
 4. `git push -u origin feature/<name>`
-5. Create PR from feature branch → `main` (triggers validation workflows: HACS, translation lint, build)
+5. Create PR from feature branch → `main` (triggers validation workflows: translation lint, build + bundle check. NOTE: hacs/action cannot be used here — it validates the branch TREE only and the tree deliberately has no `dist/`; real HACS installs from release assets instead)
 6. Wait for CI to pass, then merge
 7. Delete feature branch (local + remote)
 


### PR DESCRIPTION
Korrektur meiner eigenen Anpassung aus #303: Ich wollte die HACS-Validierung auf PRs behalten in der Annahme, sie heilt sich nach dem ersten Asset-Release. **Das war falsch** — die [Action-Doku](https://hacs.xyz/docs/publish/action/) ist eindeutig: Außerhalb des hacs/default-Repos validiert die Action den **Branch-/Tag-Baum**, Release-Assets zählen nicht, und der Struktur-Check ist nicht ignorierbar. Ohne dist/ im Baum bleibt der Check für immer rot — #196 hatte ihn völlig zu Recht entfernt.

Raus fliegt hacs/action daher aus `validate.yml` und aus beiden Release-Workflows (dort schlug der Post-Release-Validate-Step aus demselben Grund fehl — das **Release v1.3.5-beta.1 selbst ist davon unberührt und trägt alle 23 Assets**).

Was bleibt als Validierung: Translation-Lint + Build-Job mit Bundle-Vollständigkeits-Check auf jedem PR, Versions-/Bundle-Verify beim Release. Der echte HACS-Install-Pfad (Integration lädt bei getaggten Versionen alle Release-Assets) ist gegen den hacs/integration-Quellcode verifiziert und wird durch den Beta-Test im Test-System bestätigt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)