### PR TITLE
chore: Version 1.3.5 (Stable)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simon42-dashboard-strategy",
-  "version": "1.3.5-beta.1",
+  "version": "1.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simon42-dashboard-strategy",
-      "version": "1.3.5-beta.1",
+      "version": "1.3.5",
       "dependencies": {
         "js-yaml": "^4.1.0",
         "lit": "^3.3.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simon42-dashboard-strategy",
-  "version": "1.3.5-beta.1",
+  "version": "1.3.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/simon42-dashboard-strategy.ts
+++ b/src/simon42-dashboard-strategy.ts
@@ -10,7 +10,7 @@ import type { HomeAssistant } from './types/homeassistant';
 import type { Simon42StrategyConfig } from './types/strategy';
 import type { LovelaceConfig, LovelaceViewConfig } from './types/lovelace';
 
-const STRATEGY_VERSION = '1.3.5-beta.1';
+const STRATEGY_VERSION = '1.3.5';
 
 const DEBUG = new URLSearchParams(window.location.search).has('s42_debug');
 const T0 = performance.now();


### PR DESCRIPTION
Erstes Stable-Release im neuen Auslieferungsmodus (Assets am Release statt dist/ im Repo).

**Warum jetzt ein Stable:** Der Beta-Test hat eine HACS-Eigenheit aufgedeckt — HACS filtert Pre-Releases intern aus der Release-Liste. Solange das einzige Release mit Assets eine Beta ist, findet HACS daher keine Download-Quelle (`No content to download`). Mit dem Stable v1.3.5 trägt das neueste reguläre Release die Assets — derselbe Pfad, über den z. B. lovelace-mushroom ausgeliefert wird. Ab dann funktionieren auch Beta-Installationen wieder.

**Enthält gegenüber v1.3.4-beta.9:** die Quick-Win-Batches #301 + #302 (Raum-Pins-Option, Control-Reihenfolge, Translation-Lint, Russisch, Lüfter→Klima, Auto-Hide Areas, Kontakt-Toggles, Markisen-Icons, Hitzemelder) sowie den CI/CD-Umbau (#303/#304/#305). Alles auf dem Live-System getestet.

**Nach dem Merge:** Tag `v1.3.5` → CI published das Release → Installationstest → danach kommt hacs/action wieder in die Workflows (wird ab dann dauerhaft grün).

**Rollback-Plan:** Release + Tag löschen; bestehende Installationen bleiben unberührt, alte Versionen bleiben im HACS-Picker wählbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)