### PR TITLE
chore(ci): hacs/action wieder einbauen — jetzt dauerhaft grün

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,6 +10,18 @@ on:
   workflow_dispatch:
 
 jobs:
+  # Structure validation resolves against the latest STABLE release's assets
+  # (since v1.3.5 they carry the dist files) — do not remove releases with
+  # assets, or this check breaks again.
+  hacs:
+    name: HACS Validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hacs/action@main
+        with:
+          category: plugin
+
   translations:
     name: Translation Lint
     runs-on: ubuntu-latest


### PR DESCRIPTION
Wie in #305 angekündigt: Seit dem Stable-Release v1.3.5 (mit allen dist-Dateien als Assets) findet die HACS-Struktur-Validierung ihre Quelle wieder — am neuesten Stable-Release, unabhängig vom Repo-Baum. Der Check auf diesem PR ist der Live-Beweis. Damit ist auch die Voraussetzung für eine mögliche Einreichung ins HACS-Default-Repo wieder erfüllt (dort ist eine bestehende HACS Action Pflicht).

🤖 Generated with [Claude Code](https://claude.com/claude-code)