### PR TITLE
feat(editor): target_section-Dropdown aus der Section-Meta-Map ableiten

### DIFF
--- a/src/editor/StrategyEditor.ts
+++ b/src/editor/StrategyEditor.ts
@@ -1765,9 +1765,9 @@ class Simon42DashboardStrategyEditor extends LitElement {
             <label>${localize('editor.target_section')}:</label>
             <select
               @change=${(e: Event) => this._updateCustomCardField(index, 'target_section', (e.target as HTMLSelectElement).value)}>
-              ${(['custom_cards', 'overview', 'areas', 'weather', 'energy'] as const).map((key) => html`
+              ${[...Simon42DashboardStrategyEditor._sectionMeta.entries()].map(([key, meta]) => html`
                 <option value=${key} ?selected=${(card.target_section || 'custom_cards') === key}>
-                  ${localize(Simon42DashboardStrategyEditor._sectionMeta.get(key)!.labelKey)}
+                  ${localize(meta.labelKey)}
                 </option>
               `)}
             </select>


### PR DESCRIPTION
Port von PR #280 (@TheDave94, mit Co-Authored-By-Credit): Das Ziel-Section-Dropdown bei „Eigene Karten" speist sich jetzt aus `_sectionMeta` statt aus einer Hardcode-Liste — jede künftig registrierte Section (Pflanzen, Agenda, Todos … aus #270) erscheint automatisch. Single Source of Truth.

Sichtbare Änderung: Dropdown-Reihenfolge folgt der Meta-Map („Übersicht" zuerst statt „Eigene Karten"); Auswahl-Logik und Default (`custom_cards`) unverändert — auf dem Live-System verifiziert.

Lint + Build + alle 24 Unit-Tests grün. Nach dem Merge wird #280 mit Kommentar + Credit geschlossen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)