### PR TITLE
chore: Version 1.4.0-beta.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simon42-dashboard-strategy",
-  "version": "1.3.5",
+  "version": "1.4.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simon42-dashboard-strategy",
-      "version": "1.3.5",
+      "version": "1.4.0-beta.1",
       "dependencies": {
         "js-yaml": "^4.1.0",
         "lit": "^3.3.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simon42-dashboard-strategy",
-  "version": "1.3.5",
+  "version": "1.4.0-beta.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/simon42-dashboard-strategy.ts
+++ b/src/simon42-dashboard-strategy.ts
@@ -10,7 +10,7 @@ import type { HomeAssistant } from './types/homeassistant';
 import type { Simon42StrategyConfig } from './types/strategy';
 import type { LovelaceConfig, LovelaceViewConfig } from './types/lovelace';
 
-const STRATEGY_VERSION = '1.3.5';
+const STRATEGY_VERSION = '1.4.0-beta.1';
 
 const DEBUG = new URLSearchParams(window.location.search).has('s42_debug');
 const T0 = performance.now();


### PR DESCRIPTION
Erste Beta der 1.4er-Reihe — enthält die komplette TheDave94-Welle (#310): 6 neue Sections, 5 Header-Badges, Wetter-/Cover-/Batterie-/Security-/Raum-Ausbau. Minor-Bump wegen neuer Features (CLAUDE.md-Konvention). Nach dem Merge: Tag `v1.4.0-beta.1` → CI published das Pre-Release → Beta-Test via HACS im Test-System.

🤖 Generated with [Claude Code](https://claude.com/claude-code)