### PR TITLE
chore: bump version to 1.4.0-beta.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 All notable changes to this project will be documented in this file.  
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-A list of unreleased changes can be found [here](https://github.com/TheRealSimon42/simon42-dashboard-strategy/compare/v1.4.0-beta.3...HEAD).
+A list of unreleased changes can be found [here](https://github.com/TheRealSimon42/simon42-dashboard-strategy/compare/v1.4.0-beta.4...HEAD).
 
-<a name="unreleased"></a>
-## [Unreleased]
+<a name="1.4.0-beta.4"></a>
+## [1.4.0-beta.4] - 2026-07-05 (Pre-Release)
 ### Features
 - per-room custom sections: `areas_options.{areaId}.custom_sections[]` renders user-declared section blocks above or below the generated room sections (`position: top|bottom`), editable per area in the editor (closes [#222](https://github.com/TheRealSimon42/simon42-dashboard-strategy/issues/222), [#210](https://github.com/TheRealSimon42/simon42-dashboard-strategy/issues/210); per-area idea from [#298](https://github.com/TheRealSimon42/simon42-dashboard-strategy/pull/298) by @Cyberhunter88)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simon42-dashboard-strategy",
-  "version": "1.4.0-beta.3",
+  "version": "1.4.0-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simon42-dashboard-strategy",
-      "version": "1.4.0-beta.3",
+      "version": "1.4.0-beta.4",
       "dependencies": {
         "js-yaml": "^4.1.0",
         "lit": "^3.3.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simon42-dashboard-strategy",
-  "version": "1.4.0-beta.3",
+  "version": "1.4.0-beta.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/simon42-dashboard-strategy.ts
+++ b/src/simon42-dashboard-strategy.ts
@@ -10,7 +10,7 @@ import type { HomeAssistant } from './types/homeassistant';
 import type { Simon42StrategyConfig } from './types/strategy';
 import type { LovelaceConfig, LovelaceViewConfig } from './types/lovelace';
 
-const STRATEGY_VERSION = '1.4.0-beta.3';
+const STRATEGY_VERSION = '1.4.0-beta.4';
 
 const DEBUG = new URLSearchParams(window.location.search).has('s42_debug');
 const T0 = performance.now();


### PR DESCRIPTION
Versions-Bump für das Pre-Release mit den per-Raum custom_sections (#317). Nach Merge pushe ich den Tag `v1.4.0-beta.4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)