### PR TITLE
fix: Group-/Summary-Karten auf manuellen Dashboards reparieren

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 A list of unreleased changes can be found [here](https://github.com/TheRealSimon42/simon42-dashboard-strategy/compare/v1.4.0-beta.4...HEAD).
 
+<a name="unreleased"></a>
+## [Unreleased]
+### Bugfixes
+- group/summary cards work on manual dashboards again: cards self-initialize localization + registry when used outside a strategy dashboard; a later strategy init with real config always takes precedence (closes [#147](https://github.com/TheRealSimon42/simon42-dashboard-strategy/issues/147))
+
 <a name="1.4.0-beta.4"></a>
 ## [1.4.0-beta.4] - 2026-07-05 (Pre-Release)
 ### Features

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,13 @@ npm run build-dev   # Development (source maps)
 npm run watch       # Dev + auto-rebuild on file changes
 ```
 
+## Codacy Pitfalls (CI blocks on "high" findings)
+
+- **No module-level `const fn = () => ...` arrow functions** — Biome's Qwik rule false-positives on them ("Non-serializable expression must be wrapped with $(...)"). Use `function` declarations instead. Applies to src AND test files (hit 3× so far).
+- No `any` in new signatures (`Record<string, unknown>` over `Record<string, any>`)
+- No dynamic `obj[variable]` lookups on config objects — use `Map`/`Reflect.get` (detect-object-injection)
+- Findings without auth: `https://app.codacy.com/api/v3/analysis/organizations/gh/TheRealSimon42/repositories/simon42-dashboard-strategy/pull-requests/<N>/issues`
+
 ## Git & Release Workflow
 
 **Never commit directly to `main`.** Always use feature branches.

--- a/src/Registry.ts
+++ b/src/Registry.ts
@@ -88,6 +88,9 @@ class Registry {
   /** Initialization flag */
   private static _initialized: boolean = false;
 
+  /** True when the current init came from a card without strategy config. */
+  private static _standaloneInit: boolean = false;
+
   /**
    * Reset the Registry singleton between tests so each test starts with a
    * clean slate. Production code never calls this — the singleton lives for
@@ -96,6 +99,7 @@ class Registry {
    */
   static resetForTesting(): void {
     Registry._initialized = false;
+    Registry._standaloneInit = false;
   }
 
   // =====================================================================
@@ -105,11 +109,30 @@ class Registry {
   /**
    * Initialize the registry from hass object and strategy config.
    * Synchronous — reads directly from hass.entities/devices/areas.
-   * Idempotent: skips if already initialized.
+   * Idempotent: skips if already initialized — EXCEPT when the previous
+   * init was a config-less standalone init (see initializeStandalone):
+   * the strategy's real config always takes precedence and re-initializes.
    */
   static initialize(hass: HomeAssistant, config: Simon42StrategyConfig): void {
-    if (Registry._initialized) return;
+    if (Registry._initialized && !Registry._standaloneInit) return;
+    Registry._standaloneInit = false;
+    Registry._doInitialize(hass, config);
+  }
 
+  /**
+   * Config-less init for custom cards used OUTSIDE a strategy dashboard
+   * (#147: group/summary cards on manual dashboards). No-op when any init
+   * already ran. Entity visibility then follows only the registry rules
+   * (hidden/disabled/category/no-dboard label) — there is no strategy
+   * config to apply.
+   */
+  static initializeStandalone(hass: HomeAssistant): void {
+    if (Registry._initialized) return;
+    Registry._standaloneInit = true;
+    Registry._doInitialize(hass, {});
+  }
+
+  private static _doInitialize(hass: HomeAssistant, config: Simon42StrategyConfig): void {
     timeStart('registry-init');
     Registry._hass = hass;
     Registry._config = config;

--- a/src/cards/CoversGroupCard.ts
+++ b/src/cards/CoversGroupCard.ts
@@ -117,6 +117,10 @@ class Simon42CoversGroupCard extends LitElement {
   protected willUpdate(changedProps: PropertyValues): void {
     if (!changedProps.has('hass') || !this.hass) return;
 
+    // Standalone use on manual dashboards (#147): the strategy never ran,
+    // so localization + registry maps are missing — self-initialize.
+    if (!Registry.initialized) Registry.initializeStandalone(this.hass);
+
     trackHassUpdate('covers-group');
     const oldHass = changedProps.get('hass') as HomeAssistant | undefined;
 

--- a/src/cards/CoversGroupCard.ts
+++ b/src/cards/CoversGroupCard.ts
@@ -6,6 +6,7 @@ import { LitElement, html, css, nothing, type PropertyValues } from 'lit';
 import type { HomeAssistant } from '../types/homeassistant';
 import type { AreaRegistryEntry } from '../types/registries';
 import { Registry } from '../Registry';
+import { huiCardElementsReady, ensureHuiCardElements } from '../utils/hui-elements';
 import { trackHassUpdate } from '../utils/debug';
 import { localize } from '../utils/localize';
 
@@ -118,8 +119,15 @@ class Simon42CoversGroupCard extends LitElement {
     if (!changedProps.has('hass') || !this.hass) return;
 
     // Standalone use on manual dashboards (#147): the strategy never ran,
-    // so localization + registry maps are missing — self-initialize.
+    // so localization + registry maps are missing — self-initialize. HA's
+    // tile/heading elements may also be missing there (lazy per card type);
+    // load them and re-render once available.
     if (!Registry.initialized) Registry.initializeStandalone(this.hass);
+    if (!huiCardElementsReady()) {
+      void ensureHuiCardElements().then((ok) => {
+        if (ok) this.requestUpdate();
+      });
+    }
 
     trackHassUpdate('covers-group');
     const oldHass = changedProps.get('hass') as HomeAssistant | undefined;
@@ -376,6 +384,10 @@ class Simon42CoversGroupCard extends LitElement {
 
   protected render() {
     if (!this.hass || !this._cachedFilteredIds) return nothing;
+    // Children are hui-tile/heading elements — without their definitions
+    // setConfig() on them would throw (#147). ensureHuiCardElements()
+    // triggers a re-render once they arrive.
+    if (!huiCardElementsReady()) return nothing;
 
     const covers = this._getRelevantCovers();
     this.hidden = covers.length === 0;

--- a/src/cards/LightsGroupCard.ts
+++ b/src/cards/LightsGroupCard.ts
@@ -142,15 +142,14 @@ class Simon42LightsGroupCard extends LitElement {
   `;
 
   setConfig(config: LightsGroupConfig): void {
-    // Standalone-friendly default: the strategy always sets group_type,
-    // manual-dashboard users shouldn't need to know the internal values.
-    if (!config.group_type) {
-      config = { ...config, group_type: 'all' };
-    }
-    if (!['on', 'off', 'all'].includes(config.group_type)) {
+    // User YAML may omit group_type despite the declared type (manual
+    // dashboards, #147) — default to 'all' instead of an error card.
+    const raw: Partial<LightsGroupConfig> = config;
+    const normalized: LightsGroupConfig = { ...config, group_type: raw.group_type ?? 'all' };
+    if (!['on', 'off', 'all'].includes(normalized.group_type)) {
       throw new Error('You need to define group_type (on/off/all)');
     }
-    this._config = config;
+    this._config = normalized;
   }
 
   protected willUpdate(changedProps: PropertyValues): void {

--- a/src/cards/LightsGroupCard.ts
+++ b/src/cards/LightsGroupCard.ts
@@ -6,6 +6,7 @@ import { LitElement, html, css, nothing, type PropertyValues } from 'lit';
 import type { HomeAssistant, HassEntity } from '../types/homeassistant';
 import type { AreaRegistryEntry } from '../types/registries';
 import { Registry } from '../Registry';
+import { huiCardElementsReady, ensureHuiCardElements } from '../utils/hui-elements';
 import { trackHassUpdate } from '../utils/debug';
 import { localize } from '../utils/localize';
 import { stripAreaName } from '../utils/name-utils';
@@ -141,6 +142,11 @@ class Simon42LightsGroupCard extends LitElement {
   `;
 
   setConfig(config: LightsGroupConfig): void {
+    // Standalone-friendly default: the strategy always sets group_type,
+    // manual-dashboard users shouldn't need to know the internal values.
+    if (!config.group_type) {
+      config = { ...config, group_type: 'all' };
+    }
     if (!['on', 'off', 'all'].includes(config.group_type)) {
       throw new Error('You need to define group_type (on/off/all)');
     }
@@ -151,8 +157,15 @@ class Simon42LightsGroupCard extends LitElement {
     if (!changedProps.has('hass') || !this.hass) return;
 
     // Standalone use on manual dashboards (#147): the strategy never ran,
-    // so localization + registry maps are missing — self-initialize.
+    // so localization + registry maps are missing — self-initialize. HA's
+    // tile/heading elements may also be missing there (lazy per card type);
+    // load them and re-render once available.
     if (!Registry.initialized) Registry.initializeStandalone(this.hass);
+    if (!huiCardElementsReady()) {
+      void ensureHuiCardElements().then((ok) => {
+        if (ok) this.requestUpdate();
+      });
+    }
 
     trackHassUpdate('lights-group');
     const oldHass = changedProps.get('hass') as HomeAssistant | undefined;
@@ -534,6 +547,10 @@ class Simon42LightsGroupCard extends LitElement {
 
   protected render() {
     if (!this.hass || !this._cachedSourceIds) return nothing;
+    // Children are hui-tile/heading elements — without their definitions
+    // setConfig() on them would throw (#147). ensureHuiCardElements()
+    // triggers a re-render once they arrive.
+    if (!huiCardElementsReady()) return nothing;
 
     const lights = this._getRelevantLights();
     if (lights.length === 0) {

--- a/src/cards/LightsGroupCard.ts
+++ b/src/cards/LightsGroupCard.ts
@@ -150,6 +150,10 @@ class Simon42LightsGroupCard extends LitElement {
   protected willUpdate(changedProps: PropertyValues): void {
     if (!changedProps.has('hass') || !this.hass) return;
 
+    // Standalone use on manual dashboards (#147): the strategy never ran,
+    // so localization + registry maps are missing — self-initialize.
+    if (!Registry.initialized) Registry.initializeStandalone(this.hass);
+
     trackHassUpdate('lights-group');
     const oldHass = changedProps.get('hass') as HomeAssistant | undefined;
 

--- a/src/cards/SummaryCard.ts
+++ b/src/cards/SummaryCard.ts
@@ -98,6 +98,10 @@ class Simon42SummaryCard extends LitElement {
   protected willUpdate(changedProps: PropertyValues): void {
     if (!changedProps.has('hass') || !this.hass) return;
 
+    // Standalone use on manual dashboards (#147): the strategy never ran,
+    // so localization + registry maps are missing — self-initialize.
+    if (!Registry.initialized) Registry.initializeStandalone(this.hass);
+
     trackHassUpdate(`summary-${this._config.summary_type}`);
     const oldHass = changedProps.get('hass') as HomeAssistant | undefined;
 

--- a/src/utils/hui-elements.ts
+++ b/src/utils/hui-elements.ts
@@ -1,0 +1,58 @@
+// ====================================================================
+// hui element loader (standalone card support, #147)
+// ====================================================================
+// The group cards build their children with document.createElement on
+// HA-internal elements (hui-tile-card, hui-heading-card). HA defines
+// card elements lazily PER CARD TYPE — on a strategy dashboard tiles
+// are everywhere so the definitions are always present, but a manual
+// dashboard without any tile/heading card never loads them. Calling
+// setConfig() on such an un-upgraded element throws and the card dies.
+//
+// This helper force-loads the definitions through HA's semi-public
+// window.loadCardHelpers() API: creating a card via the helpers makes
+// HA import + define the element class. Cards guard their render on
+// huiCardElementsReady() and re-render once the promise resolves.
+// ====================================================================
+
+interface CardHelpers {
+  createCardElement(config: Record<string, unknown>): unknown;
+}
+
+let ensurePromise: Promise<boolean> | null = null;
+
+/** True when HA's tile + heading card elements are defined. */
+export function huiCardElementsReady(): boolean {
+  return !!(customElements.get('hui-tile-card') && customElements.get('hui-heading-card'));
+}
+
+/**
+ * Loads hui-tile-card / hui-heading-card definitions if missing.
+ * Resolves true when both are defined; false when loadCardHelpers is
+ * unavailable (very old HA) — cards then stay hidden instead of dying.
+ */
+export function ensureHuiCardElements(): Promise<boolean> {
+  if (huiCardElementsReady()) return Promise.resolve(true);
+  if (ensurePromise) return ensurePromise;
+
+  ensurePromise = loadDefinitions();
+  return ensurePromise;
+}
+
+async function loadDefinitions(): Promise<boolean> {
+  try {
+    const w = window as unknown as { loadCardHelpers?: () => Promise<CardHelpers> };
+    if (typeof w.loadCardHelpers !== 'function') return false;
+    const helpers = await w.loadCardHelpers();
+    // Creating the cards forces HA to import + define the element classes.
+    // The elements are thrown away — we only need the definitions.
+    helpers.createCardElement({ type: 'tile', entity: 'sun.sun' });
+    helpers.createCardElement({ type: 'heading', heading: '' });
+    await Promise.all([
+      customElements.whenDefined('hui-tile-card'),
+      customElements.whenDefined('hui-heading-card'),
+    ]);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/utils/hui-elements.ts
+++ b/src/utils/hui-elements.ts
@@ -34,7 +34,11 @@ export function ensureHuiCardElements(): Promise<boolean> {
   if (huiCardElementsReady()) return Promise.resolve(true);
   if (ensurePromise) return ensurePromise;
 
-  ensurePromise = loadDefinitions();
+  // Belt and braces: loadDefinitions already try/catches, the extra catch
+  // satisfies static analysis that the promise can never reject.
+  ensurePromise = loadDefinitions().catch(function swallow(): boolean {
+    return false;
+  });
   return ensurePromise;
 }
 

--- a/tests/Registry.standalone.test.ts
+++ b/tests/Registry.standalone.test.ts
@@ -1,0 +1,71 @@
+// ============================================================================
+// Tests — Registry standalone init (#147: cards on manual dashboards)
+// ============================================================================
+// Locks down the precedence contract:
+//   1. initializeStandalone works without strategy config (cards render)
+//   2. a LATER strategy initialize() with real config re-initializes —
+//      a standalone init must never lock out the strategy's config filters
+//   3. standalone after a full init is a no-op (config filters survive)
+// ============================================================================
+
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { Registry } from '../src/Registry';
+import { makeHass } from './fixtures/hass';
+
+const HASS = () =>
+  makeHass({
+    areas: [{ area_id: 'living', name: 'Wohnzimmer' }],
+    entities: [
+      { entity_id: 'light.sofa', state: 'on', area_id: 'living' },
+      { entity_id: 'light.decke', state: 'off', area_id: 'living' },
+    ],
+  });
+
+// Strategy config that hides light.sofa in the living room
+const HIDING_CONFIG = {
+  areas_options: {
+    living: { groups_options: { lights: { hidden: ['light.sofa'] } } },
+  },
+};
+
+beforeEach(() => {
+  Registry.resetForTesting();
+});
+
+describe('Registry.initializeStandalone', () => {
+  it('initializes without strategy config (registry rules only)', () => {
+    Registry.initializeStandalone(HASS());
+    expect(Registry.initialized).toBe(true);
+    expect(Registry.getVisibleEntityIdsForDomain('light').sort()).toEqual([
+      'light.decke',
+      'light.sofa',
+    ]);
+  });
+
+  it('is a no-op when a full init already ran (config filters survive)', () => {
+    const hass = HASS();
+    Registry.initialize(hass, HIDING_CONFIG);
+    Registry.initializeStandalone(hass);
+    expect(Registry.getVisibleEntityIdsForDomain('light')).toEqual(['light.decke']);
+  });
+
+  it('does not lock out a later strategy init — real config re-initializes', () => {
+    const hass = HASS();
+    // Card on a manual dashboard initializes first (no config)...
+    Registry.initializeStandalone(hass);
+    expect(Registry.getVisibleEntityIdsForDomain('light')).toHaveLength(2);
+    // ...then the strategy dashboard generates with its real config.
+    Registry.initialize(hass, HIDING_CONFIG);
+    expect(Registry.getVisibleEntityIdsForDomain('light')).toEqual(['light.decke']);
+  });
+
+  it('strategy initialize stays idempotent after taking over', () => {
+    const hass = HASS();
+    Registry.initializeStandalone(hass);
+    Registry.initialize(hass, HIDING_CONFIG);
+    // Second strategy call (other view strategies) must not re-init again
+    Registry.initialize(hass, {});
+    expect(Registry.getVisibleEntityIdsForDomain('light')).toEqual(['light.decke']);
+  });
+});

--- a/tests/Registry.standalone.test.ts
+++ b/tests/Registry.standalone.test.ts
@@ -13,14 +13,15 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { Registry } from '../src/Registry';
 import { makeHass } from './fixtures/hass';
 
-const HASS = () =>
-  makeHass({
+function HASS(): ReturnType<typeof makeHass> {
+  return makeHass({
     areas: [{ area_id: 'living', name: 'Wohnzimmer' }],
     entities: [
       { entity_id: 'light.sofa', state: 'on', area_id: 'living' },
       { entity_id: 'light.decke', state: 'off', area_id: 'living' },
     ],
   });
+}
 
 // Strategy config that hides light.sofa in the living room
 const HIDING_CONFIG = {


### PR DESCRIPTION
## Was ist das?

Bugfix für #147: Die Custom Cards (`simon42-lights-group-card`, `simon42-covers-group-card`, `simon42-summary-card`) waren auf **manuellen** Dashboards kaputt. Es gab ZWEI Ursachen:

## Ursache 1: localize/Registry nie initialisiert

Beides passiert nur beim Strategy-`generate()`. Fix: `Registry.initializeStandalone(hass)` (inkl. `setupLocalize`), von den Karten in `willUpdate` selbst angestoßen. **Vorrang-Regel:** Eine spätere Strategy-Initialisierung mit echter Config re-initialisiert immer — eine zuerst ladende Karte kann der Strategy nie die Config-Filter aussperren (4 Tests decken den Vertrag ab).

## Ursache 2 (der eigentliche Killer): hui-Elemente fehlen

Die Gruppen-Karten bauen ihre Kinder mit `document.createElement('hui-tile-card' / 'hui-heading-card')` — HA definiert Karten-Elemente aber **lazy pro Kartentyp**. Ein manuelles Dashboard ohne Tile-/Heading-Karte lädt die Definitionen nie; `setConfig()` auf dem nicht-upgegradeten Element wirft und die Karte stirbt. Auf Strategy-Dashboards fiel das nie auf (Tiles überall).

Fix: `utils/hui-elements.ts` lädt die Definitionen bei Bedarf über HAs `loadCardHelpers()`-API nach; `render()` wartet mit Guard darauf und re-rendert, sobald sie da sind. Auf Strategy-Dashboards ist der Guard immer sofort wahr — null Verhaltensänderung.

## Bonus

`group_type` defaultet standalone auf `'all'` statt eine rote Fehlerkarte zu werfen — die Strategy setzt das Feld immer, manuelle Nutzer müssen die internen Werte nicht kennen.

## Test

- [x] 42/42 Unit-Tests (4 neue für den Vorrang-Vertrag)
- [ ] Simons Re-Test: Group Card auf manuellem Dashboard (auch eins OHNE andere Tile-Karten!) → rendert mit Übersetzungen; Strategy-Dashboard danach → Config-Filter greifen weiter

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)