### PR TITLE
[codex] Deduplicate room entities before categorization

### DIFF
--- a/src/utils/entity-utils.ts
+++ b/src/utils/entity-utils.ts
@@ -1,0 +1,8 @@
+export function uniqueEntitiesById<T extends { entity_id: string }>(entities: readonly T[]): T[] {
+  const seenEntityIds = new Set<string>();
+  return entities.filter((entity) => {
+    if (seenEntityIds.has(entity.entity_id)) return false;
+    seenEntityIds.add(entity.entity_id);
+    return true;
+  });
+}

--- a/src/views/RoomViewStrategy.ts
+++ b/src/views/RoomViewStrategy.ts
@@ -17,6 +17,7 @@ import { Registry } from '../Registry';
 import { timeStart, timeEnd, debugLog } from '../utils/debug';
 import { localize } from '../utils/localize';
 import { BADGE_COLOR_MAP, getColorForEntity, isDefaultShowName, resolveShowName } from '../utils/badge-utils';
+import { uniqueEntitiesById } from '../utils/entity-utils';
 
 // HA supported_features bitmask values
 const FAN_SET_SPEED = 1;
@@ -134,7 +135,7 @@ class Simon42ViewRoomStrategy extends HTMLElement {
 
     // Main categorization loop — use pre-filtered visible entities from Registry
     // (no hidden, no_dboard, config/diagnostic, config-hidden)
-    const visibleEntities = Registry.getVisibleEntitiesForArea(area.area_id);
+    const visibleEntities = uniqueEntitiesById(Registry.getVisibleEntitiesForArea(area.area_id));
 
     // Filter unavailable entities from per-room domain lists / sensor badges.
     // Default true: unavailable items are noise in a room view (offline devices,

--- a/tests/utils/entity-utils.test.ts
+++ b/tests/utils/entity-utils.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { uniqueEntitiesById } from '../../src/utils/entity-utils';
+
+describe('uniqueEntitiesById', () => {
+  it('keeps the first occurrence of each entity id', () => {
+    const light = { entity_id: 'light.living_room', source: 'first' };
+    const duplicateLight = { entity_id: 'light.living_room', source: 'duplicate' };
+    const camera = { entity_id: 'camera.driveway', source: 'first' };
+
+    expect(uniqueEntitiesById([light, duplicateLight, camera, camera])).toEqual([light, camera]);
+  });
+});


### PR DESCRIPTION
## What changed

- deduplicate visible room entities by `entity_id` before categorization
- keep the first registry entry when duplicate entries are present
- add a focused unit test for the deduplication behavior

## Why

Duplicate entity registry entries can cause the same light, camera, sensor, or other room entity to be rendered more than once. Deduplicating once before categorization prevents duplicate room cards and badges without changing normal entity ordering.

## Validation

- `npm test` — 39 tests passed
- `npx tsc --noEmit`
- `npm run lint` — no errors; one pre-existing unused-import warning in `StrategyEditor.ts`
- `npm run build`
