### PR TITLE
Add UPS sections and room stack ordering

### DIFF
--- a/src/editor/StrategyEditor.ts
+++ b/src/editor/StrategyEditor.ts
@@ -4300,6 +4300,8 @@ async function getAreaGroupedEntities(areaId: string, hass: HomeAssistant): Prom
     automations: [],
     scripts: [],
     cameras: [],
+    ups: [],
+    energy: [],
   };
 
   const excludeLabels = entities

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -91,6 +91,9 @@
     "battery_one": "Batterie",
     "battery_many": "Batterien"
   },
+  "ups": {
+    "battery": "Akku"
+  },
   "climate": {
     "heating": "Heizen",
     "cooling": "Kühlen",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -91,6 +91,9 @@
     "battery_one": "battery",
     "battery_many": "batteries"
   },
+  "ups": {
+    "battery": "Battery"
+  },
   "climate": {
     "heating": "Heating",
     "cooling": "Cooling",

--- a/src/translations/ru.json
+++ b/src/translations/ru.json
@@ -91,6 +91,9 @@
     "battery_one": "Батарейка",
     "battery_many": "Батарейки"
   },
+  "ups": {
+    "battery": "Батарея"
+  },
   "climate": {
     "heating": "Обогрев",
     "cooling": "Охлаждение",

--- a/src/types/strategy.ts
+++ b/src/types/strategy.ts
@@ -45,6 +45,43 @@ export const ALL_HEADING_KEYS: HeadingKey[] = [
   'energy',
 ];
 
+// -- Stack Ordering (per-area room view) ------------------------------
+
+export type StackKey =
+  | 'ups'
+  | 'energy'
+  | 'cameras'
+  | 'lights'
+  | 'locks'
+  | 'climate'
+  | 'covers'
+  | 'covers_curtain'
+  | 'covers_window'
+  | 'media'
+  | 'scenes'
+  | 'misc'
+  | 'automations'
+  | 'scripts'
+  | 'room_pins';
+
+export const DEFAULT_STACKS_ORDER: StackKey[] = [
+  'ups',
+  'energy',
+  'cameras',
+  'lights',
+  'locks',
+  'climate',
+  'covers',
+  'covers_curtain',
+  'covers_window',
+  'media',
+  'scenes',
+  'misc',
+  'automations',
+  'scripts',
+  'room_pins',
+];
+
 // -- Main Strategy Config ---------------------------------------------
 
 export interface Simon42StrategyConfig {
@@ -102,6 +139,7 @@ export interface Simon42StrategyConfig {
   show_locks_in_rooms?: boolean; // default: false
   show_automations_in_rooms?: boolean; // default: false
   show_scripts_in_rooms?: boolean; // default: false
+  show_ups_in_rooms?: boolean; // default: true (opt-out)
   show_cameras_in_rooms?: boolean; // default: true
   show_window_contacts_in_rooms?: boolean; // default: true (opt-out — set false to hide window contact badges)
   show_door_contacts_in_rooms?: boolean; // default: true (opt-out — set false to hide door contact badges)
@@ -200,6 +238,7 @@ export interface AreaOptions {
   groups_options?: Record<string, GroupOptions>;
   /** User-declared sections for this area's room view (top/bottom) */
   custom_sections?: AreaCustomSection[];
+  stacks_order?: StackKey[]; // default: DEFAULT_STACKS_ORDER
 }
 
 export interface GroupOptions {
@@ -359,6 +398,8 @@ export interface RoomEntities {
   automations: string[];
   scripts: string[];
   cameras: string[];
+  ups: string[];
+  energy: string[];
   [key: string]: string[];
 }
 

--- a/src/utils/name-utils.ts
+++ b/src/utils/name-utils.ts
@@ -8,7 +8,7 @@
 import { Registry } from '../Registry';
 import type { HomeAssistant } from '../types/homeassistant';
 import type { AreaRegistryEntry, EntityRegistryEntry } from '../types/registries';
-import type { AreasDisplay } from '../types/strategy';
+import { DEFAULT_STACKS_ORDER, type AreasDisplay, type StackKey } from '../types/strategy';
 
 // -- Module-level RegExp caches (shared across all calls) -------------
 
@@ -204,4 +204,24 @@ export function sortByFriendlyName(a: string, b: string, hass: HomeAssistant): n
   const nameA = stateA?.attributes?.friendly_name || a;
   const nameB = stateB?.attributes?.friendly_name || b;
   return nameA.localeCompare(nameB);
+}
+
+function mergeConfiguredOrder<T extends string>(stored: T[] | undefined, defaults: readonly T[]): T[] {
+  if (!stored || stored.length === 0) return [...defaults];
+
+  const validKeys = new Set(defaults);
+  const seen = new Set<T>();
+  const known: T[] = [];
+
+  for (const key of stored) {
+    if (!validKeys.has(key) || seen.has(key)) continue;
+    known.push(key);
+    seen.add(key);
+  }
+
+  return [...known, ...defaults.filter((key) => !seen.has(key))];
+}
+
+export function mergeStacksOrder(stored?: StackKey[]): StackKey[] {
+  return mergeConfiguredOrder(stored, DEFAULT_STACKS_ORDER);
 }

--- a/src/views/RoomViewStrategy.ts
+++ b/src/views/RoomViewStrategy.ts
@@ -10,7 +10,7 @@ import type {
   LovelaceBadgeConfig,
 } from '../types/lovelace';
 import type { AreaRegistryEntry, EntityRegistryEntry } from '../types/registries';
-import type { AreaCustomSection, RoomEntities, SensorEntities, StackKey } from '../types/strategy';
+import type { AreaCustomSection, GroupOptions, RoomEntities, SensorEntities, StackKey } from '../types/strategy';
 import { mergeStacksOrder, sortByFriendlyName, sortByLastChanged, stripAreaName } from '../utils/name-utils';
 import { buildAreaCustomSections } from '../sections/CustomSections';
 import { Registry } from '../Registry';
@@ -50,6 +50,105 @@ interface UpsDeviceRender {
   name: string;
   batteryId: string;
   sensorIds: string[];
+}
+
+type RoomGroupKey = keyof RoomEntities;
+type RoomGroupsOptions = Partial<Record<RoomGroupKey | 'badges', GroupOptions>>;
+
+const ROOM_GROUP_KEYS: RoomGroupKey[] = [
+  'lights',
+  'covers',
+  'covers_curtain',
+  'covers_window',
+  'scenes',
+  'climate',
+  'media_player',
+  'vacuum',
+  'fan',
+  'humidifier',
+  'valve',
+  'water_heater',
+  'switches',
+  'locks',
+  'automations',
+  'scripts',
+  'cameras',
+  'ups',
+  'energy',
+];
+
+function getRoomEntityList(roomEntities: RoomEntities, key: RoomGroupKey): string[] {
+  switch (key) {
+    case 'lights': return roomEntities.lights;
+    case 'covers': return roomEntities.covers;
+    case 'covers_curtain': return roomEntities.covers_curtain;
+    case 'covers_window': return roomEntities.covers_window;
+    case 'scenes': return roomEntities.scenes;
+    case 'climate': return roomEntities.climate;
+    case 'media_player': return roomEntities.media_player;
+    case 'vacuum': return roomEntities.vacuum;
+    case 'fan': return roomEntities.fan;
+    case 'humidifier': return roomEntities.humidifier;
+    case 'valve': return roomEntities.valve;
+    case 'water_heater': return roomEntities.water_heater;
+    case 'switches': return roomEntities.switches;
+    case 'locks': return roomEntities.locks;
+    case 'automations': return roomEntities.automations;
+    case 'scripts': return roomEntities.scripts;
+    case 'cameras': return roomEntities.cameras;
+    case 'ups': return roomEntities.ups;
+    case 'energy': return roomEntities.energy;
+    default: return [];
+  }
+}
+
+function setRoomEntityList(roomEntities: RoomEntities, key: RoomGroupKey, value: string[]): void {
+  switch (key) {
+    case 'lights': roomEntities.lights = value; return;
+    case 'covers': roomEntities.covers = value; return;
+    case 'covers_curtain': roomEntities.covers_curtain = value; return;
+    case 'covers_window': roomEntities.covers_window = value; return;
+    case 'scenes': roomEntities.scenes = value; return;
+    case 'climate': roomEntities.climate = value; return;
+    case 'media_player': roomEntities.media_player = value; return;
+    case 'vacuum': roomEntities.vacuum = value; return;
+    case 'fan': roomEntities.fan = value; return;
+    case 'humidifier': roomEntities.humidifier = value; return;
+    case 'valve': roomEntities.valve = value; return;
+    case 'water_heater': roomEntities.water_heater = value; return;
+    case 'switches': roomEntities.switches = value; return;
+    case 'locks': roomEntities.locks = value; return;
+    case 'automations': roomEntities.automations = value; return;
+    case 'scripts': roomEntities.scripts = value; return;
+    case 'cameras': roomEntities.cameras = value; return;
+    case 'ups': roomEntities.ups = value; return;
+    case 'energy': roomEntities.energy = value; return;
+  }
+}
+
+function getGroupOptions(groupsOptions: RoomGroupsOptions, key: RoomGroupKey): GroupOptions | undefined {
+  switch (key) {
+    case 'lights': return groupsOptions.lights;
+    case 'covers': return groupsOptions.covers;
+    case 'covers_curtain': return groupsOptions.covers_curtain;
+    case 'covers_window': return groupsOptions.covers_window;
+    case 'scenes': return groupsOptions.scenes;
+    case 'climate': return groupsOptions.climate;
+    case 'media_player': return groupsOptions.media_player;
+    case 'vacuum': return groupsOptions.vacuum;
+    case 'fan': return groupsOptions.fan;
+    case 'humidifier': return groupsOptions.humidifier;
+    case 'valve': return groupsOptions.valve;
+    case 'water_heater': return groupsOptions.water_heater;
+    case 'switches': return groupsOptions.switches;
+    case 'locks': return groupsOptions.locks;
+    case 'automations': return groupsOptions.automations;
+    case 'scripts': return groupsOptions.scripts;
+    case 'cameras': return groupsOptions.cameras;
+    case 'ups': return groupsOptions.ups;
+    case 'energy': return groupsOptions.energy;
+    default: return undefined;
+  }
 }
 
 function findUpsEntityGroups(entities: EntityRegistryEntry[], hass: HomeAssistant): UpsEntityGroup[] {
@@ -159,7 +258,7 @@ class Simon42ViewRoomStrategy extends HTMLElement {
 
     // Ensure Registry is initialized (idempotent — no-op if already done)
     Registry.initialize(hass, dashboardConfig);
-    const groupsOptions: Record<string, any> = config.groups_options || {};
+    const groupsOptions: RoomGroupsOptions = config.groups_options || {};
     const areaCustomSections: AreaCustomSection[] = config.custom_sections || [];
 
     const roomEntities: RoomEntities = {
@@ -365,22 +464,23 @@ class Simon42ViewRoomStrategy extends HTMLElement {
     }
 
     const applyGroupFilter = (groupKey: keyof RoomEntities): string[] => {
-      const groupOpts = groupsOptions[groupKey];
-      if (!groupOpts) return roomEntities[groupKey];
-      let filtered = roomEntities[groupKey];
-      if (groupOpts.hidden?.length > 0) {
+      const groupOpts = getGroupOptions(groupsOptions, groupKey);
+      let filtered = getRoomEntityList(roomEntities, groupKey);
+      if (!groupOpts) return filtered;
+      if ((groupOpts.hidden?.length ?? 0) > 0) {
         const hiddenSet = new Set<string>(groupOpts.hidden);
         filtered = filtered.filter((e: string) => !hiddenSet.has(e));
       }
-      if (groupOpts.order?.length > 0) {
-        const orderMap = new Map<string, number>(groupOpts.order.map((id: string, i: number) => [id, i]));
+      if ((groupOpts.order?.length ?? 0) > 0) {
+        const orderValues = groupOpts.order ?? [];
+        const orderMap = new Map<string, number>(orderValues.map((id: string, i: number) => [id, i]));
         filtered.sort((a: string, b: string) => (orderMap.get(a) ?? 9999) - (orderMap.get(b) ?? 9999));
       }
       return filtered;
     };
 
-    for (const key of Object.keys(roomEntities) as (keyof RoomEntities)[]) {
-      roomEntities[key] = applyGroupFilter(key);
+    for (const key of ROOM_GROUP_KEYS) {
+      setRoomEntityList(roomEntities, key, applyGroupFilter(key));
     }
 
     const upsDevices: UpsDeviceRender[] = [];

--- a/src/views/RoomViewStrategy.ts
+++ b/src/views/RoomViewStrategy.ts
@@ -53,7 +53,7 @@ interface UpsDeviceRender {
 }
 
 function hasOwnState(states: HomeAssistant['states'], entityId: string): boolean {
-  return Object.prototype.hasOwnProperty.call(states, entityId);
+  return Object.keys(states).some((stateId) => stateId === entityId);
 }
 
 function getEntityState(
@@ -63,6 +63,13 @@ function getEntityState(
   if (!hasOwnState(hass.states, entityId)) return undefined;
   const entry = Object.entries(hass.states).find(([id]) => id === entityId);
   return entry?.[1];
+}
+
+function getEntityDeviceClass(
+  hass: HomeAssistant,
+  entityId: string
+): string | undefined {
+  return getEntityState(hass, entityId)?.attributes?.device_class as string | undefined;
 }
 
 type RoomGroupKey = keyof RoomEntities;
@@ -211,7 +218,7 @@ function findUpsEntityGroups(entities: EntityRegistryEntry[], hass: HomeAssistan
 }
 
 function upsSensorRole(entityId: string, hass: HomeAssistant): number {
-  const deviceClass = getEntityState(hass, entityId)?.attributes?.device_class as string | undefined;
+  const deviceClass = getEntityDeviceClass(hass, entityId);
   if (deviceClass === 'duration' || /runtime|time_left|load_runtime/.test(entityId)) return 1;
   if (deviceClass === 'power' || deviceClass === 'apparent_power' || /(^|[._])load([._]|$)/.test(entityId)) return 2;
   if (deviceClass === 'voltage' || /voltage|input/.test(entityId)) return 3;
@@ -659,7 +666,7 @@ class Simon42ViewRoomStrategy extends HTMLElement {
     if (roomEntities.energy.length > 0) {
       const energyEntities = roomEntities.energy
         .map((entityId) => {
-          const deviceClass = hass.states[entityId]?.attributes?.device_class as string | undefined;
+          const deviceClass = getEntityDeviceClass(hass, entityId);
           return {
             entityId,
             order: ROOM_ENERGY_SENSOR_CLASSES.indexOf(deviceClass as (typeof ROOM_ENERGY_SENSOR_CLASSES)[number]),

--- a/src/views/RoomViewStrategy.ts
+++ b/src/views/RoomViewStrategy.ts
@@ -9,9 +9,9 @@ import type {
   LovelaceSectionConfig,
   LovelaceBadgeConfig,
 } from '../types/lovelace';
-import type { AreaRegistryEntry } from '../types/registries';
-import type { AreaCustomSection, RoomEntities, SensorEntities } from '../types/strategy';
-import { sortByFriendlyName, sortByLastChanged, stripAreaName } from '../utils/name-utils';
+import type { AreaRegistryEntry, EntityRegistryEntry } from '../types/registries';
+import type { AreaCustomSection, RoomEntities, SensorEntities, StackKey } from '../types/strategy';
+import { mergeStacksOrder, sortByFriendlyName, sortByLastChanged, stripAreaName } from '../utils/name-utils';
 import { buildAreaCustomSections } from '../sections/CustomSections';
 import { Registry } from '../Registry';
 import { timeStart, timeEnd, debugLog } from '../utils/debug';
@@ -23,6 +23,10 @@ const FAN_SET_SPEED = 1;
 const MEDIA_PAUSE = 1;
 const MEDIA_PLAY = 16384;
 const MEDIA_STOP = 4096;
+const UPS_DEVICE_CLASSES = new Set(['duration', 'apparent_power', 'power', 'voltage']);
+const UPS_ID_PATTERN = /load|runtime|time_left|input_voltage|status/;
+const ROOM_ENERGY_SENSOR_CLASSES = ['power', 'energy', 'water', 'gas'] as const;
+const ROOM_ENERGY_SENSOR_CLASS_SET = new Set<string>(ROOM_ENERGY_SENSOR_CLASSES);
 
 /** Check if a fan supports speed control */
 function fanSupportsSpeed(state: HassEntity): boolean {
@@ -35,6 +39,74 @@ function mediaPlayerSupportsPlayback(state: HassEntity): boolean {
   return (f & (MEDIA_PAUSE | MEDIA_PLAY | MEDIA_STOP)) !== 0;
 }
 
+interface UpsEntityGroup {
+  deviceId: string;
+  batteryId: string;
+  sensorIds: string[];
+  entityIds: string[];
+}
+
+interface UpsDeviceRender {
+  name: string;
+  batteryId: string;
+  sensorIds: string[];
+}
+
+function findUpsEntityGroups(entities: EntityRegistryEntry[], hass: HomeAssistant): UpsEntityGroup[] {
+  const entitiesByDevice = new Map<string, EntityRegistryEntry[]>();
+  for (const entity of entities) {
+    if (!entity.device_id) continue;
+    const bucket = entitiesByDevice.get(entity.device_id);
+    if (bucket) bucket.push(entity);
+    else entitiesByDevice.set(entity.device_id, [entity]);
+  }
+
+  const groups: UpsEntityGroup[] = [];
+  for (const [deviceId, deviceEntities] of entitiesByDevice) {
+    let batteryId: string | undefined;
+    let hasUpsSignal = false;
+    let isNut = false;
+
+    for (const entity of deviceEntities) {
+      if (entity.platform === 'nut') isNut = true;
+
+      const state = hass.states[entity.entity_id];
+      if (!state) continue;
+      const deviceClass = state.attributes?.device_class as string | undefined;
+      const unit = state.attributes?.unit_of_measurement as string | undefined;
+
+      if (!batteryId && entity.entity_id.startsWith('sensor.') && deviceClass === 'battery' && unit === '%') {
+        batteryId = entity.entity_id;
+        continue;
+      }
+
+      if (deviceClass && UPS_DEVICE_CLASSES.has(deviceClass)) hasUpsSignal = true;
+      else if (UPS_ID_PATTERN.test(entity.entity_id)) hasUpsSignal = true;
+    }
+
+    if (!batteryId || (!isNut && !hasUpsSignal)) continue;
+    groups.push({
+      deviceId,
+      batteryId,
+      entityIds: deviceEntities.map((entity) => entity.entity_id),
+      sensorIds: deviceEntities
+        .map((entity) => entity.entity_id)
+        .filter((entityId) => entityId !== batteryId && !!hass.states[entityId]),
+    });
+  }
+
+  return groups;
+}
+
+function upsSensorRole(entityId: string, hass: HomeAssistant): number {
+  const deviceClass = hass.states[entityId]?.attributes?.device_class as string | undefined;
+  if (deviceClass === 'duration' || /runtime|time_left|load_runtime/.test(entityId)) return 1;
+  if (deviceClass === 'power' || deviceClass === 'apparent_power' || /(^|[._])load([._]|$)/.test(entityId)) return 2;
+  if (deviceClass === 'voltage' || /voltage|input/.test(entityId)) return 3;
+  if (/status|state/.test(entityId)) return 4;
+  return 5;
+}
+
 /** Config fields consumed by the room-pins section */
 interface RoomPinsConfig {
   room_pin_entities?: string[];
@@ -45,17 +117,17 @@ interface RoomPinsConfig {
 
 /** Filter all configured room pins for the ones in the given area */
 function getAreasRoomPins(config: RoomPinsConfig, area: AreaRegistryEntry): string[] {
-    const roomPinEntities: string[] = config.room_pin_entities || [];
-    return roomPinEntities.filter((entityId) => {
-      const entity = Registry.getEntity(entityId);
-      if (!entity) return false;
-      if (entity.area_id === area.area_id) return true;
-      if (entity.device_id) {
-        const device = Registry.getDevice(entity.device_id);
-        if (device?.area_id === area.area_id) return true;
-      }
-      return false;
-    });
+  const roomPinEntities: string[] = config.room_pin_entities || [];
+  return roomPinEntities.filter((entityId) => {
+    const entity = Registry.getEntity(entityId);
+    if (!entity) return false;
+    if (entity.area_id === area.area_id) return true;
+    if (entity.device_id) {
+      const device = Registry.getDevice(entity.device_id);
+      if (device?.area_id === area.area_id) return true;
+    }
+    return false;
+  });
 }
 
 /** Build the tile-card factory for room-pin entities */
@@ -88,7 +160,6 @@ class Simon42ViewRoomStrategy extends HTMLElement {
     // Ensure Registry is initialized (idempotent — no-op if already done)
     Registry.initialize(hass, dashboardConfig);
     const groupsOptions: Record<string, any> = config.groups_options || {};
-    // User-declared sections for this room (areas_options.{areaId}.custom_sections)
     const areaCustomSections: AreaCustomSection[] = config.custom_sections || [];
 
     const roomEntities: RoomEntities = {
@@ -109,6 +180,8 @@ class Simon42ViewRoomStrategy extends HTMLElement {
       automations: [],
       scripts: [],
       cameras: [],
+      ups: [],
+      energy: [],
     };
 
     const sensorEntities: SensorEntities = {
@@ -132,24 +205,21 @@ class Simon42ViewRoomStrategy extends HTMLElement {
       heat: [],
     };
 
-    // Main categorization loop — use pre-filtered visible entities from Registry
-    // (no hidden, no_dboard, config/diagnostic, config-hidden)
     const visibleEntities = Registry.getVisibleEntitiesForArea(area.area_id);
+    const showUps = dashboardConfig.show_ups_in_rooms !== false;
+    const upsGroups = showUps ? findUpsEntityGroups(visibleEntities, hass) : [];
+    const usedByUps = new Set(upsGroups.flatMap(({ entityIds }) => entityIds));
+    roomEntities.ups.push(...usedByUps);
 
-    // Filter unavailable entities from per-room domain lists / sensor badges.
-    // Default true: unavailable items are noise in a room view (offline devices,
-    // dead batteries surface elsewhere via the batteries view + alert badge).
     const hideUnavailable = dashboardConfig.hide_unavailable_in_rooms !== false;
 
     for (const entity of visibleEntities) {
       const entityId = entity.entity_id;
-
-      // State check
       const state = hass.states[entityId];
       if (!state) continue;
       if (hideUnavailable && state.state === 'unavailable') continue;
+      if (usedByUps.has(entityId)) continue;
 
-      // Domain categorization
       const domain = entityId.split('.')[0];
       const deviceClass = state.attributes?.device_class as string | undefined;
       const unit = state.attributes?.unit_of_measurement as string | undefined;
@@ -216,21 +286,18 @@ class Simon42ViewRoomStrategy extends HTMLElement {
         roomEntities.cameras.push(entityId);
         continue;
       }
+      if (domain === 'sensor' && deviceClass && ROOM_ENERGY_SENSOR_CLASS_SET.has(deviceClass)) {
+        roomEntities.energy.push(entityId);
+        continue;
+      }
 
-      // Sensors for badges
       if (domain === 'sensor') {
         if (entityId.includes('battery') || deviceClass === 'battery') {
           const val = parseFloat(state.state);
           if (!isNaN(val) && val < 20) sensorEntities.battery.push(entityId);
           continue;
         }
-        // Temperature and humidity badges are only shown when explicitly
-        // assigned in HA area settings (area.temperature_entity_id / humidity_entity_id).
-        // No auto-detection — avoids wrong sensors (e.g. heater temperature).
         if (deviceClass === 'temperature' || unit === '°C' || unit === '°F') continue;
-        // Soil/plant moisture sensors are auto-detected (device_class === 'moisture'
-        // on sensor.* — distinct from binary_sensor.moisture which means a leak).
-        // Check before the '%' fallthrough so we don't lose them.
         if (deviceClass === 'moisture') {
           sensorEntities.soil_moisture.push(entityId);
           continue;
@@ -297,7 +364,6 @@ class Simon42ViewRoomStrategy extends HTMLElement {
       }
     }
 
-    // Apply groups_options filters
     const applyGroupFilter = (groupKey: keyof RoomEntities): string[] => {
       const groupOpts = groupsOptions[groupKey];
       if (!groupOpts) return roomEntities[groupKey];
@@ -317,9 +383,13 @@ class Simon42ViewRoomStrategy extends HTMLElement {
       roomEntities[key] = applyGroupFilter(key);
     }
 
-    // === BADGES ===
+    const upsDevices: UpsDeviceRender[] = [];
+    for (const { deviceId, batteryId, sensorIds } of upsGroups) {
+      const device = Registry.getDevice(deviceId);
+      const name = device?.name_by_user ?? device?.name ?? 'UPS';
+      upsDevices.push({ name, batteryId, sensorIds });
+    }
 
-    // Primary temp/humidity from area config (always shown, not filterable)
     let primaryTemp: string | null = null;
     let primaryHumidity: string | null = null;
 
@@ -338,7 +408,6 @@ class Simon42ViewRoomStrategy extends HTMLElement {
       primaryHumidity = area.humidity_entity_id;
     }
 
-    // Build auto-detected badge candidates
     const badgeOpts = groupsOptions.badges;
     const hasBadgeConfig = !!badgeOpts;
 
@@ -349,9 +418,6 @@ class Simon42ViewRoomStrategy extends HTMLElement {
     }
 
     const candidates: BadgeCandidate[] = [];
-
-    // Auto-detected sensors (first match per type, except window/door which show all)
-    // Colors from shared BADGE_COLOR_MAP, show_name from shared isDefaultShowName()
     const addCandidate = (entityId: string, colorKey: string, dcOverride?: string) => {
       const dc = dcOverride || (hass.states[entityId]?.attributes?.device_class as string | undefined);
       candidates.push({
@@ -361,7 +427,6 @@ class Simon42ViewRoomStrategy extends HTMLElement {
       });
     };
 
-    // Single-match sensor types
     const singleTypes: Array<[string[], string]> = [
       [sensorEntities.pm1, 'pm1'],
       [sensorEntities.pm25, 'pm25'],
@@ -382,9 +447,6 @@ class Simon42ViewRoomStrategy extends HTMLElement {
       if (entities[0]) addCandidate(entities[0], colorKey);
     }
 
-    // Window/door: show ALL matches (not just first), users control via per-area hidden[]
-    // Per-domain opt-out via show_window_contacts_in_rooms / show_door_contacts_in_rooms
-    // (default true — preserves prior behavior; set false to silence the badge type).
     if (dashboardConfig.show_window_contacts_in_rooms !== false) {
       for (const id of sensorEntities.window) addCandidate(id, 'window', 'window');
     }
@@ -392,7 +454,6 @@ class Simon42ViewRoomStrategy extends HTMLElement {
       for (const id of sensorEntities.door) addCandidate(id, 'door', 'door');
     }
 
-    // Apply per-area badge config: filter hidden, append additional
     let filteredCandidates = candidates;
     if (hasBadgeConfig) {
       if (badgeOpts.hidden?.length) {
@@ -408,11 +469,9 @@ class Simon42ViewRoomStrategy extends HTMLElement {
       }
     }
 
-    // Resolve show_name per badge: default + config overrides
     const namesVisible = hasBadgeConfig ? new Set<string>(badgeOpts.names_visible || []) : null;
     const namesHidden = hasBadgeConfig ? new Set<string>(badgeOpts.names_hidden || []) : null;
 
-    // Convert to LovelaceBadgeConfig
     const badges: LovelaceBadgeConfig[] = [];
     if (primaryTemp) badges.push({ type: 'entity', entity: primaryTemp, color: 'red', tap_action: { action: 'more-info' } });
     if (primaryHumidity) badges.push({ type: 'entity', entity: primaryHumidity, color: 'indigo', tap_action: { action: 'more-info' } });
@@ -427,12 +486,90 @@ class Simon42ViewRoomStrategy extends HTMLElement {
       });
     }
 
-    // === SECTIONS ===
-    // Custom sections with position 'top' render before all generated
-    // sections; 'bottom' ones are appended at the very end.
     const sections: LovelaceSectionConfig[] = buildAreaCustomSections(areaCustomSections, 'top');
+    const areaOptions = dashboardConfig.areas_options?.[area.area_id];
+    const configuredStacksOrder = areaOptions?.stacks_order;
+    let stacksOrder = mergeStacksOrder(configuredStacksOrder);
+    if (!configuredStacksOrder && dashboardConfig.room_pins_first === true) {
+      stacksOrder = ['room_pins', ...stacksOrder.filter((key) => key !== 'room_pins')];
+    }
+    const stacks = new Map<StackKey, LovelaceSectionConfig[]>();
 
-    // Cameras
+    function pushStack(key: StackKey, section: LovelaceSectionConfig): void {
+      const current = stacks.get(key) ?? [];
+      current.push(section);
+      stacks.set(key, current);
+    }
+
+    if (upsDevices.length > 0) {
+      const critThreshold = dashboardConfig.battery_critical_threshold ?? 20;
+      const lowThreshold = dashboardConfig.battery_low_threshold ?? 50;
+      const hiddenUpsEntities = new Set<string>(groupsOptions.ups?.hidden || []);
+
+      for (const upsDevice of upsDevices) {
+        if (hiddenUpsEntities.has(upsDevice.batteryId)) continue;
+
+        const sortedSensors = [...upsDevice.sensorIds]
+          .sort((a, b) => upsSensorRole(a, hass) - upsSensorRole(b, hass) || a.localeCompare(b))
+          .filter((entityId) => !hiddenUpsEntities.has(entityId));
+
+        pushStack('ups', {
+          type: 'grid',
+          cards: [
+            {
+              type: 'heading',
+              heading_style: 'title',
+              icon: 'mdi:power-plug-battery',
+              heading: upsDevice.name,
+            },
+            {
+              type: 'gauge',
+              entity: upsDevice.batteryId,
+              name: localize('ups.battery'),
+              min: 0,
+              max: 100,
+              needle: false,
+              severity: { red: 0, yellow: critThreshold, green: lowThreshold },
+            },
+            ...sortedSensors.map((entityId) => ({
+              type: 'tile',
+              entity: entityId,
+              name: stripAreaName(entityId, area, hass),
+              vertical: false,
+              state_content: 'state',
+            })),
+          ],
+        });
+      }
+    }
+
+    if (roomEntities.energy.length > 0) {
+      const energyEntities = roomEntities.energy
+        .map((entityId) => {
+          const deviceClass = hass.states[entityId]?.attributes?.device_class as string | undefined;
+          return {
+            entityId,
+            order: ROOM_ENERGY_SENSOR_CLASSES.indexOf(deviceClass as (typeof ROOM_ENERGY_SENSOR_CLASSES)[number]),
+          };
+        })
+        .sort((a, b) => a.order - b.order || a.entityId.localeCompare(b.entityId))
+        .map((entry) => entry.entityId);
+
+      pushStack('energy', {
+        type: 'grid',
+        cards: [
+          { type: 'heading', heading: localize('sections.energy'), heading_style: 'title', icon: 'mdi:lightning-bolt' },
+          ...energyEntities.map((entityId) => ({
+            type: 'tile',
+            entity: entityId,
+            name: stripAreaName(entityId, area, hass),
+            vertical: false,
+            state_content: 'state',
+          })),
+        ],
+      });
+    }
+
     if (roomEntities.cameras.length > 0) {
       const cameraCards: LovelaceCardConfig[] = [];
       for (const cameraId of roomEntities.cameras) {
@@ -454,8 +591,6 @@ class Simon42ViewRoomStrategy extends HTMLElement {
 
         if ((isReolink || isAqara) && deviceId) {
           const devEntities = Registry.getEntityIdsForDevice(deviceId);
-
-          // Reolink-specific entities
           const spotlight = devEntities.find(
             (id) => id.startsWith('light.') && hass.states[id] && !Registry.isEntityExcluded(id)
           );
@@ -468,8 +603,6 @@ class Simon42ViewRoomStrategy extends HTMLElement {
           const siren = devEntities.find(
             (id) => id.startsWith('siren.') && hass.states[id] && !Registry.isEntityExcluded(id)
           );
-
-          // Aqara-specific entities
           const battery = devEntities.find(
             (id) =>
               id.startsWith('sensor.') &&
@@ -483,7 +616,7 @@ class Simon42ViewRoomStrategy extends HTMLElement {
               !Registry.isEntityExcluded(id)
           );
 
-          const glanceEntities: any[] = [];
+          const glanceEntities: Array<{ entity: string }> = [];
           if (isReolink) {
             if (spotlight) glanceEntities.push({ entity: spotlight });
             if (motion) glanceEntities.push({ entity: motion });
@@ -515,14 +648,13 @@ class Simon42ViewRoomStrategy extends HTMLElement {
         }
       }
       if (cameraCards.length > 0) {
-        sections.push({
+        pushStack('cameras', {
           type: 'grid',
           cards: [{ type: 'heading', heading: localize('room.cameras'), heading_style: 'title', icon: 'mdi:cctv' }, ...cameraCards],
         });
       }
     }
 
-    // Sort lights by last_changed or alphabetically (unless custom order)
     if (!groupsOptions.lights?.order) {
       if (dashboardConfig.lights_sort_by === 'name') {
         roomEntities.lights.sort((a, b) => sortByFriendlyName(a, b, hass));
@@ -531,32 +663,22 @@ class Simon42ViewRoomStrategy extends HTMLElement {
       }
     }
 
-    // Helper: create a domain section
     const domainSection = (
+      key: StackKey,
       entities: string[],
       heading: string,
       icon: string,
       tileConfig: (e: string) => LovelaceCardConfig
     ): void => {
       if (entities.length === 0) return;
-      sections.push({
+      pushStack(key, {
         type: 'grid',
         cards: [{ type: 'heading', heading, heading_style: 'title', icon }, ...entities.map(tileConfig)],
       });
     };
 
-    // Room pins render as the last section by default; opt-in `room_pins_first` moves them to the top (#189)
-    if (dashboardConfig.room_pins_first === true) {
-      domainSection(
-        getAreasRoomPins(dashboardConfig, area),
-        localize('room.room_pins'),
-        'mdi:pin',
-        buildRoomPinTile(dashboardConfig, area, hass)
-      );
-    }
-
     if (roomEntities.lights.length > 0) {
-      sections.push({
+      pushStack('lights', {
         type: 'grid',
         cards: [
           {
@@ -574,7 +696,7 @@ class Simon42ViewRoomStrategy extends HTMLElement {
       });
     }
 
-    domainSection(roomEntities.locks, localize('room.locks'), 'mdi:lock', (e) => ({
+    domainSection('locks', roomEntities.locks, localize('room.locks'), 'mdi:lock', (e) => ({
       type: 'tile',
       entity: e,
       name: stripAreaName(e, area, hass),
@@ -584,7 +706,6 @@ class Simon42ViewRoomStrategy extends HTMLElement {
       state_content: 'last_changed',
     }));
 
-    // Climate + Fan combined into one "Klima" section
     if (roomEntities.climate.length > 0 || roomEntities.fan.length > 0) {
       const climateCards: LovelaceCardConfig[] = [
         { type: 'heading', heading: localize('room.climate'), heading_style: 'title', icon: 'mdi:thermostat' },
@@ -612,10 +733,10 @@ class Simon42ViewRoomStrategy extends HTMLElement {
           state_content: 'last_changed',
         });
       }
-      sections.push({ type: 'grid', cards: climateCards });
+      pushStack('climate', { type: 'grid', cards: climateCards });
     }
 
-    domainSection(roomEntities.covers, localize('room.covers'), 'mdi:window-shutter', (e) => ({
+    domainSection('covers', roomEntities.covers, localize('room.covers'), 'mdi:window-shutter', (e) => ({
       type: 'tile',
       entity: e,
       name: stripAreaName(e, area, hass),
@@ -625,7 +746,7 @@ class Simon42ViewRoomStrategy extends HTMLElement {
       state_content: ['current_position', 'last_changed'],
     }));
 
-    domainSection(roomEntities.covers_curtain, localize('room.curtains'), 'mdi:curtains', (e) => ({
+    domainSection('covers_curtain', roomEntities.covers_curtain, localize('room.curtains'), 'mdi:curtains', (e) => ({
       type: 'tile',
       entity: e,
       name: stripAreaName(e, area, hass),
@@ -635,7 +756,7 @@ class Simon42ViewRoomStrategy extends HTMLElement {
       state_content: ['current_position', 'last_changed'],
     }));
 
-    domainSection(roomEntities.covers_window, localize('room.windows'), 'mdi:window-open-variant', (e) => ({
+    domainSection('covers_window', roomEntities.covers_window, localize('room.windows'), 'mdi:window-open-variant', (e) => ({
       type: 'tile',
       entity: e,
       name: stripAreaName(e, area, hass),
@@ -645,7 +766,7 @@ class Simon42ViewRoomStrategy extends HTMLElement {
       state_content: ['current_position', 'last_changed'],
     }));
 
-    domainSection(roomEntities.media_player, localize('room.media'), 'mdi:speaker', (e) => {
+    domainSection('media', roomEntities.media_player, localize('room.media'), 'mdi:speaker', (e) => {
       const state = hass.states[e];
       const hasPlayback = state && mediaPlayerSupportsPlayback(state);
       return {
@@ -658,7 +779,7 @@ class Simon42ViewRoomStrategy extends HTMLElement {
       };
     });
 
-    domainSection(roomEntities.scenes, localize('room.scenes'), 'mdi:palette', (e) => ({
+    domainSection('scenes', roomEntities.scenes, localize('room.scenes'), 'mdi:palette', (e) => ({
       type: 'tile',
       entity: e,
       name: stripAreaName(e, area, hass),
@@ -666,7 +787,6 @@ class Simon42ViewRoomStrategy extends HTMLElement {
       state_content: 'last_changed',
     }));
 
-    // Misc (vacuum, fan, switches)
     const miscCards: LovelaceCardConfig[] = [];
     for (const e of roomEntities.vacuum)
       miscCards.push({
@@ -725,7 +845,7 @@ class Simon42ViewRoomStrategy extends HTMLElement {
     });
 
     if (miscCards.length > 0) {
-      sections.push({
+      pushStack('misc', {
         type: 'grid',
         cards: [
           { type: 'heading', heading: localize('room.misc'), heading_style: 'title', icon: 'mdi:dots-horizontal' },
@@ -734,7 +854,7 @@ class Simon42ViewRoomStrategy extends HTMLElement {
       });
     }
 
-    domainSection(roomEntities.automations, localize('room.automations'), 'mdi:robot', (e) => ({
+    domainSection('automations', roomEntities.automations, localize('room.automations'), 'mdi:robot', (e) => ({
       type: 'tile',
       entity: e,
       name: stripAreaName(e, area, hass),
@@ -742,20 +862,21 @@ class Simon42ViewRoomStrategy extends HTMLElement {
       state_content: 'last_changed',
     }));
 
-    domainSection(roomEntities.scripts, localize('room.scripts'), 'mdi:script-text', (e) => ({
+    domainSection('scripts', roomEntities.scripts, localize('room.scripts'), 'mdi:script-text', (e) => ({
       type: 'tile',
       entity: e,
       name: stripAreaName(e, area, hass),
       vertical: false,
     }));
 
-    if (dashboardConfig.room_pins_first !== true) {
-      domainSection(
-        getAreasRoomPins(dashboardConfig, area),
-        localize('room.room_pins'),
-        'mdi:pin',
-        buildRoomPinTile(dashboardConfig, area, hass)
-      );
+    const roomPins = getAreasRoomPins(dashboardConfig, area);
+    if (roomPins.length > 0) {
+      domainSection('room_pins', roomPins, localize('room.room_pins'), 'mdi:pin', buildRoomPinTile(dashboardConfig, area, hass));
+    }
+
+    for (const key of stacksOrder) {
+      const stackSections = stacks.get(key);
+      if (stackSections) sections.push(...stackSections);
     }
 
     sections.push(...buildAreaCustomSections(areaCustomSections, 'bottom'));

--- a/src/views/RoomViewStrategy.ts
+++ b/src/views/RoomViewStrategy.ts
@@ -52,6 +52,19 @@ interface UpsDeviceRender {
   sensorIds: string[];
 }
 
+function hasOwnState(states: HomeAssistant['states'], entityId: string): boolean {
+  return Object.prototype.hasOwnProperty.call(states, entityId);
+}
+
+function getEntityState(
+  hass: HomeAssistant,
+  entityId: string
+): HassEntity | undefined {
+  if (!hasOwnState(hass.states, entityId)) return undefined;
+  const entry = Object.entries(hass.states).find(([id]) => id === entityId);
+  return entry?.[1];
+}
+
 type RoomGroupKey = keyof RoomEntities;
 type RoomGroupsOptions = Partial<Record<RoomGroupKey | 'badges', GroupOptions>>;
 
@@ -190,7 +203,7 @@ function findUpsEntityGroups(entities: EntityRegistryEntry[], hass: HomeAssistan
       entityIds: deviceEntities.map((entity) => entity.entity_id),
       sensorIds: deviceEntities
         .map((entity) => entity.entity_id)
-        .filter((entityId) => entityId !== batteryId && !!hass.states[entityId]),
+        .filter((entityId) => entityId !== batteryId && !!getEntityState(hass, entityId)),
     });
   }
 
@@ -198,7 +211,7 @@ function findUpsEntityGroups(entities: EntityRegistryEntry[], hass: HomeAssistan
 }
 
 function upsSensorRole(entityId: string, hass: HomeAssistant): number {
-  const deviceClass = hass.states[entityId]?.attributes?.device_class as string | undefined;
+  const deviceClass = getEntityState(hass, entityId)?.attributes?.device_class as string | undefined;
   if (deviceClass === 'duration' || /runtime|time_left|load_runtime/.test(entityId)) return 1;
   if (deviceClass === 'power' || deviceClass === 'apparent_power' || /(^|[._])load([._]|$)/.test(entityId)) return 2;
   if (deviceClass === 'voltage' || /voltage|input/.test(entityId)) return 3;

--- a/tests/utils/name-utils.test.ts
+++ b/tests/utils/name-utils.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import { mergeStacksOrder } from '../../src/utils/name-utils';
+
+describe('mergeStacksOrder', () => {
+  it('returns the default order when nothing is configured', () => {
+    expect(mergeStacksOrder()).toEqual([
+      'ups',
+      'energy',
+      'cameras',
+      'lights',
+      'locks',
+      'climate',
+      'covers',
+      'covers_curtain',
+      'covers_window',
+      'media',
+      'scenes',
+      'misc',
+      'automations',
+      'scripts',
+      'room_pins',
+    ]);
+  });
+
+  it('keeps configured keys first and appends missing defaults', () => {
+    expect(mergeStacksOrder(['lights', 'energy', 'room_pins'])).toEqual([
+      'lights',
+      'energy',
+      'room_pins',
+      'ups',
+      'cameras',
+      'locks',
+      'climate',
+      'covers',
+      'covers_curtain',
+      'covers_window',
+      'media',
+      'scenes',
+      'misc',
+      'automations',
+      'scripts',
+    ]);
+  });
+
+  it('drops duplicates and unknown keys', () => {
+    expect(mergeStacksOrder(['lights', 'lights', 'unknown' as never, 'misc'])).toEqual([
+      'lights',
+      'misc',
+      'ups',
+      'energy',
+      'cameras',
+      'locks',
+      'climate',
+      'covers',
+      'covers_curtain',
+      'covers_window',
+      'media',
+      'scenes',
+      'automations',
+      'scripts',
+      'room_pins',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add generic UPS detection for room views and render a dedicated UPS block per device
- add per-area room stack ordering so generated sections can be reordered without forking the strategy
- include energy sensors in room stacks and cover the stack-order merge helper with tests

## Testing
- npx tsc --noEmit
- npm run lint *(1 existing upstream warning in StrategyEditor.ts: unused PropertyValues import)*
- npm run build
- npm test *(fails locally on this Windows sandbox with Vite spawn EPERM before tests run)*