### PR TITLE
feat: HA 2026.x alignment — Registry-Staleness-Fix, Strategy-Registrierung, Picker-Cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -326,5 +326,6 @@ Local reference copies for architecture and pattern lookup (sparse checkouts, re
 | `../references/ha-strategies/` | `home-assistant/frontend` → `src/panels/lovelace/strategies/` | Official HA strategies (TypeScript, architecture reference) |
 | `../references/mushroom-strategy/` | `DigiLive/mushroom-strategy` | Community dashboard strategy (TypeScript + build pipeline reference) |
 | `../references/hacs-docs/` | `hacs/documentation` → `source/docs/publish/` | HACS publishing documentation (hacs.json options, release handling) |
+| `../references/ha-dev-blog/` | `home-assistant/developers.home-assistant` → `blog/` | HA developer blog (frontend/API changes per release — check when aligning with new HA versions) |
 
 **HA Release Notes (Markdown)**: `https://github.com/home-assistant/home-assistant.io/blob/rc/source/_posts/` — Blog posts in MD format. Example for April 2026: `2026-04-01-release-20264.markdown`. Useful for checking which HA features/changes are current and whether issues have become obsolete due to HA updates.

--- a/src/Registry.ts
+++ b/src/Registry.ts
@@ -27,7 +27,8 @@ import { setupLocalize } from './utils/localize';
  * any other access.
  *
  * Reads directly from hass.entities/devices/areas (synchronous, no WebSocket
- * calls). All members are static, all maps are built once on initialize().
+ * calls). All members are static; maps are built on initialize() and rebuilt
+ * only when the hass registries change (reference compare).
  */
 class Registry {
   // Prevent instantiation
@@ -105,10 +106,16 @@ class Registry {
   /**
    * Initialize the registry from hass object and strategy config.
    * Synchronous — reads directly from hass.entities/devices/areas.
-   * Idempotent: skips if already initialized.
+   * Idempotent while the hass registry references are unchanged. When HA
+   * regenerates the strategy after a registry change (new/renamed entities,
+   * devices, areas, floors), the changed reference triggers a full rebuild —
+   * otherwise views would keep serving the snapshot from the first page load.
+   * The config is deliberately NOT part of the staleness check: standalone
+   * view strategies pass `config.config || {}` (a fresh object per call),
+   * which would clobber the dashboard config on every generate.
    */
   static initialize(hass: HomeAssistant, config: Simon42StrategyConfig): void {
-    if (Registry._initialized) return;
+    if (Registry._initialized && !Registry._registriesChanged(hass)) return;
 
     timeStart('registry-init');
     Registry._hass = hass;
@@ -141,6 +148,21 @@ class Registry {
       `Registry initialized: ${Registry._fetchedEntities.length} entities, ${Registry._fetchedDevices.length} devices, ${Registry._fetchedAreas.length} areas`
     );
     timeEnd('registry-init');
+  }
+
+  /**
+   * Whether the hass registries have changed since the last initialize().
+   * HA replaces the registry collections on hass (immutable updates), so a
+   * reference compare is sufficient and cheap — same pattern the SummaryCard
+   * uses for its entity cache invalidation.
+   */
+  private static _registriesChanged(hass: HomeAssistant): boolean {
+    return (
+      hass.entities !== Registry._hass.entities ||
+      hass.devices !== Registry._hass.devices ||
+      hass.areas !== Registry._hass.areas ||
+      hass.floors !== Registry._hass.floors
+    );
   }
 
   // =====================================================================

--- a/src/cards/SummaryCard.ts
+++ b/src/cards/SummaryCard.ts
@@ -9,12 +9,6 @@ import { trackHassUpdate, debugLog, timeStart, timeEnd } from '../utils/debug';
 import { localize } from '../utils/localize';
 import { getBatteryEntities, SECURITY_EXCLUDED_PLATFORMS } from '../utils/entity-filter';
 
-declare global {
-  interface Window {
-    customCards?: Array<{ type: string; name: string; description: string }>;
-  }
-}
-
 type SummaryType = 'lights' | 'covers' | 'security' | 'batteries' | 'climate';
 
 interface SummaryCardConfig {
@@ -344,9 +338,6 @@ class Simon42SummaryCard extends LitElement {
 
 customElements.define('simon42-summary-card', Simon42SummaryCard);
 
-window.customCards = window.customCards || [];
-window.customCards.push({
-  type: 'simon42-summary-card',
-  name: 'Simon42 Summary Card',
-  description: 'Reactive summary card that counts entities dynamically',
-});
+// Deliberately NOT registered in window.customCards: the card only works
+// inside the strategy (Registry + localize lifecycle, see #147). Listing it
+// in the card picker would invite standalone use that breaks.

--- a/src/simon42-dashboard-strategy.ts
+++ b/src/simon42-dashboard-strategy.ts
@@ -36,6 +36,18 @@ const modulesPromise = Promise.all([
 void modulesPromise.then(() => { t('all chunks loaded'); });
 
 class Simon42DashboardStrategy extends HTMLElement {
+  // HA 2026.7+: only regenerate when one of these registries actually changed
+  // (reference compare on the hass object). Matches HA's current default set —
+  // declared explicitly because the Registry's staleness check relies on
+  // exactly these four references. Labels need no entry: label assignments
+  // live on entity registry entries, so they bump `entities`.
+  static registryDependencies = ['entities', 'devices', 'areas', 'floors'] as const;
+
+  // HA 2026.5+: suggested title/icon in the "new dashboard" dialog.
+  static getCreateSuggestions(): { title: string; icon: string } {
+    return { title: 'Simon42 Dashboard', icon: 'mdi:view-dashboard' };
+  }
+
   static async generate(config: Simon42StrategyConfig, hass: HomeAssistant): Promise<LovelaceConfig> {
     generateCallCount++;
     t(`generate() called (#${generateCallCount})`);
@@ -171,5 +183,29 @@ class Simon42DashboardStrategy extends HTMLElement {
 // Register strategy custom element IMMEDIATELY — no heavy imports needed.
 // This ensures HA's 5-second timeout is satisfied even on slow networks.
 customElements.define('ll-strategy-simon42-dashboard', Simon42DashboardStrategy);
+
+// HA 2026.5+: register in the "new dashboard" dialog (Community dashboards
+// section) so users can create the dashboard without the YAML detour. HA keeps
+// the same array reference, so push order vs. frontend load order is irrelevant.
+declare global {
+  interface Window {
+    customStrategies?: Array<{
+      type: string;
+      strategyType: 'dashboard' | 'view' | 'section';
+      name?: string;
+      description?: string;
+      documentationURL?: string;
+    }>;
+  }
+}
+window.customStrategies = window.customStrategies || [];
+window.customStrategies.push({
+  type: 'simon42-dashboard',
+  strategyType: 'dashboard',
+  name: 'Simon42 Dashboard',
+  description:
+    'Automatisch generiertes Dashboard aus deinen Bereichen, Geräten und Entitäten — mit Zusammenfassungen, Raum-Ansichten und flexibler Konfiguration.',
+  documentationURL: 'https://github.com/TheRealSimon42/simon42-dashboard-strategy',
+});
 
 console.log(`Simon42 Dashboard Strategy v${STRATEGY_VERSION} loaded`);

--- a/tests/Registry.test.ts
+++ b/tests/Registry.test.ts
@@ -1,0 +1,94 @@
+// ============================================================================
+// Tests — Registry initialization & staleness handling
+// ============================================================================
+// The Registry is a static singleton. Within one generate pass, repeated
+// initialize() calls must be no-ops (idempotency). But when HA regenerates
+// the strategy after a registry change, hass carries NEW collection objects
+// (immutable updates) — initialize() must then rebuild, otherwise views keep
+// serving the snapshot from the first page load.
+// ============================================================================
+
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { Registry } from '../src/Registry';
+import { makeHass } from './fixtures/hass';
+
+beforeEach(() => {
+  Registry.resetForTesting();
+});
+
+describe('Registry.initialize', () => {
+  it('is a no-op while the hass registry references are unchanged', () => {
+    const hass = makeHass({
+      areas: [{ area_id: 'kitchen', name: 'Kitchen' }],
+      entities: [{ entity_id: 'light.kitchen', area_id: 'kitchen' }],
+    });
+    Registry.initialize(hass, {});
+    const before = Registry.getVisibleEntitiesForArea('kitchen');
+
+    // Same references (HA re-calls generate without registry changes)
+    Registry.initialize(hass, {});
+    expect(Registry.getVisibleEntitiesForArea('kitchen')).toBe(before);
+  });
+
+  it('rebuilds when hass.entities is a new reference (registry changed)', () => {
+    const hass = makeHass({
+      areas: [{ area_id: 'kitchen', name: 'Kitchen' }],
+      entities: [{ entity_id: 'light.kitchen', area_id: 'kitchen' }],
+    });
+    Registry.initialize(hass, {});
+    expect(Registry.getVisibleEntitiesForArea('kitchen')).toHaveLength(1);
+
+    // Simulate an entity added in HA: new hass with a NEW entities object
+    const updated = makeHass({
+      areas: [{ area_id: 'kitchen', name: 'Kitchen' }],
+      entities: [
+        { entity_id: 'light.kitchen', area_id: 'kitchen' },
+        { entity_id: 'light.kitchen_2', area_id: 'kitchen' },
+      ],
+    });
+    Registry.initialize(updated, {});
+
+    const ids = Registry.getVisibleEntitiesForArea('kitchen').map(
+      function toId(e) { return e.entity_id; }
+    );
+    expect(ids).toEqual(['light.kitchen', 'light.kitchen_2']);
+  });
+
+  it('rebuilds when hass.areas is a new reference (area renamed/added)', () => {
+    const hass = makeHass({
+      areas: [{ area_id: 'kitchen', name: 'Kitchen' }],
+      entities: [{ entity_id: 'light.kitchen', area_id: 'kitchen' }],
+    });
+    Registry.initialize(hass, {});
+    expect(Registry.areas.map(function toName(a) { return a.name; })).toEqual(['Kitchen']);
+
+    const updated = makeHass({
+      areas: [{ area_id: 'kitchen', name: 'Küche' }],
+      entities: [{ entity_id: 'light.kitchen', area_id: 'kitchen' }],
+    });
+    Registry.initialize(updated, {});
+    expect(Registry.areas.map(function toName(a) { return a.name; })).toEqual(['Küche']);
+  });
+
+  it('picks up the current config on a registry-triggered rebuild', () => {
+    const hass = makeHass({
+      areas: [{ area_id: 'kitchen', name: 'Kitchen' }],
+      entities: [{ entity_id: 'light.kitchen', area_id: 'kitchen' }],
+    });
+    Registry.initialize(hass, {});
+    expect(Registry.getVisibleEntitiesForArea('kitchen')).toHaveLength(1);
+
+    const updated = makeHass({
+      areas: [{ area_id: 'kitchen', name: 'Kitchen' }],
+      entities: [{ entity_id: 'light.kitchen', area_id: 'kitchen' }],
+    });
+    const config = {
+      areas_options: {
+        kitchen: { groups_options: { light: { hidden: ['light.kitchen'] } } },
+      },
+    };
+    Registry.initialize(updated, config);
+    expect(Registry.getVisibleEntitiesForArea('kitchen')).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Was ist drin

**1. Registry: Rebuild bei Registry-Änderungen (Bugfix)**
Die Registry behielt bisher den Snapshot vom ersten Seitenaufruf (`_initialized`-Guard ohne Staleness-Check). HA regeneriert Strategy-Dashboards aber automatisch bei Änderungen an Entitäten/Geräten/Bereichen/Etagen — die Regeneration lief bei uns ins Leere, Änderungen wurden erst nach Hard-Reload sichtbar. Jetzt: Referenz-Vergleich auf die vier hass-Registries, bei Änderung voller Rebuild (gleiches Muster wie die Cache-Invalidierung der SummaryCard). Die Config ist bewusst NICHT Teil des Checks (Standalone-View-Strategies übergeben `config.config || {}` — frisches Objekt pro Aufruf).

**2. HA 2026.5/2026.7-Features (Entry Point)**
- `window.customStrategies`-Registrierung: Die Strategy erscheint im „Neues Dashboard"-Dialog unter **Community dashboards** — kein YAML-Umweg mehr für neue Nutzer
- `getCreateSuggestions`: Titel-/Icon-Vorschlag im Dialog
- `static registryDependencies = ['entities', 'devices', 'areas', 'floors']` (HA 2026.7, explizit deklariert — Labels brauchen keinen Eintrag, Label-Zuweisungen bumpen `entities`)

**3. SummaryCard aus dem Karten-Picker entfernt**
Die Karte funktioniert nur im Strategy-Kontext (#147) — der `window.customCards`-Eintrag hat zur kaputten Standalone-Nutzung eingeladen. Bestehende Configs sind nicht betroffen (Element bleibt registriert).

Dazu: 4 neue Registry-Tests (Idempotenz, Rebuild bei Referenzwechsel, Config-Übernahme beim Rebuild) und die ha-dev-blog-Referenz in der CLAUDE.md.

## Getestet

- `npm test` (42 Tests), `tsc --noEmit`, Lint (nur die bekannte Bestands-Warning), Build ✅
- Live auf HA 2026.7.1: Bereich umbenennen → Dashboard aktualisiert **ohne Reload**; „Simon42 Dashboard" erscheint im Neues-Dashboard-Dialog; Summary Card nicht mehr im Picker; Übersicht/Räume/Editor ohne Auffälligkeiten

🤖 Generated with [Claude Code](https://claude.com/claude-code)