### PR TITLE
chore: bump version to 1.4.0-beta.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simon42-dashboard-strategy",
-  "version": "1.4.0-beta.6",
+  "version": "1.4.0-beta.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simon42-dashboard-strategy",
-      "version": "1.4.0-beta.6",
+      "version": "1.4.0-beta.7",
       "dependencies": {
         "js-yaml": "^4.1.0",
         "lit": "^3.3.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simon42-dashboard-strategy",
-  "version": "1.4.0-beta.6",
+  "version": "1.4.0-beta.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/simon42-dashboard-strategy.ts
+++ b/src/simon42-dashboard-strategy.ts
@@ -10,7 +10,7 @@ import type { HomeAssistant } from './types/homeassistant';
 import type { Simon42StrategyConfig } from './types/strategy';
 import type { LovelaceConfig, LovelaceViewConfig } from './types/lovelace';
 
-const STRATEGY_VERSION = '1.4.0-beta.6';
+const STRATEGY_VERSION = '1.4.0-beta.7';
 
 const DEBUG = new URLSearchParams(window.location.search).has('s42_debug');
 const T0 = performance.now();


### PR DESCRIPTION
Version-Bump für die nächste Beta. Enthaltene Änderungen seit beta.6:

- #329 — HA 2026.x alignment: Registry-Staleness-Fix (Regeneration greift jetzt wirklich), `window.customStrategies`-Registrierung (Community-Dashboards-Dialog), `registryDependencies`, SummaryCard aus dem Karten-Picker
- #330 — Raum-Features: opt-in Saug- & Mähroboter-Section, Mähroboter-Bugfix (`lawn_mower` wurde nie kategorisiert), Kameras pro Raum abschaltbar (Editor-Gruppe, ausgegraut bei globalem Aus)

Nach dem Merge: Tag `v1.4.0-beta.7` auf main pushen → Release-Workflow published die Pre-Release-Assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)