### PR TITLE
ci: HACS Validation bei Fork-PRs überspringen

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,6 +16,10 @@ jobs:
   hacs:
     name: HACS Validation
     runs-on: ubuntu-latest
+    # Bei Fork-PRs überspringen: hacs/action validiert sonst das FORK-Repo
+    # (kein Release mit Assets vorhanden → "not compliant", siehe PR #324).
+    # Push/Schedule/Dispatch und Same-Repo-PRs laufen weiter normal.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v4
       - uses: hacs/action@main


### PR DESCRIPTION
## Problem

Der Job **HACS Validation** in `validate.yml` schlägt bei Pull Requests aus Forks fehl: `hacs/action` validiert dann das **Fork-Repo** (z. B. `Cyberhunter88/...`) statt des Basis-Repos. Da Forks keine Releases mit `dist`-Assets haben, scheitert die Struktur-Validierung dort immer mit *"Repository structure ... is not compliant / not loaded properly in HACS"*.

**Beleg:** PR #324 (Fork-PR, [Run 28734742781](https://github.com/TheRealSimon42/simon42-dashboard-strategy/actions/runs/28734742781) — nur HACS Validation rot, alle anderen Jobs grün) vs. PR #322 (Same-Repo-PR, grün).

## Fix

`if`-Bedingung am Job:

```yaml
if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
```

- **Fork-PRs:** Job wird geskippt (die Validierung wäre dort ohnehin aussagelos, weil sie das falsche Repo prüft)
- **Same-Repo-PRs, Push auf main, Schedule, Dispatch:** laufen unverändert
- `main` hat keine Required-Status-Checks (weder Branch Protection noch Rulesets geprüft) — ein geskippter Job blockiert also keine Merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)