### PR TITLE
chore: bump version to 1.4.0-beta.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 All notable changes to this project will be documented in this file.  
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-A list of unreleased changes can be found [here](https://github.com/TheRealSimon42/simon42-dashboard-strategy/compare/v1.4.0-beta.9...HEAD).
+A list of unreleased changes can be found [here](https://github.com/TheRealSimon42/simon42-dashboard-strategy/compare/v1.4.0-beta.10...HEAD).
+
+<a name="1.4.0-beta.10"></a>
+## [1.4.0-beta.10] - 2026-07-06 (Pre-Release)
+### Changes
+- rooms: the camera wrapper card with play/stop live toggle (introduced in beta.9) is now **opt-in** via `camera_live_toggle` (sub-toggle in the editor). By default room cameras render exactly as before beta.9: auto-refreshing picture-glance/picture-entity cards, Aqara cameras live ([#342](https://github.com/TheRealSimon42/simon42-dashboard-strategy/pull/342))
 
 <a name="1.4.0-beta.9"></a>
 ## [1.4.0-beta.9] - 2026-07-06 (Pre-Release)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simon42-dashboard-strategy",
-  "version": "1.4.0-beta.9",
+  "version": "1.4.0-beta.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simon42-dashboard-strategy",
-      "version": "1.4.0-beta.9",
+      "version": "1.4.0-beta.10",
       "dependencies": {
         "js-yaml": "^4.1.0",
         "lit": "^3.3.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simon42-dashboard-strategy",
-  "version": "1.4.0-beta.9",
+  "version": "1.4.0-beta.10",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/simon42-dashboard-strategy.ts
+++ b/src/simon42-dashboard-strategy.ts
@@ -10,7 +10,7 @@ import type { HomeAssistant } from './types/homeassistant';
 import type { Simon42StrategyConfig } from './types/strategy';
 import type { LovelaceConfig, LovelaceViewConfig } from './types/lovelace';
 
-const STRATEGY_VERSION = '1.4.0-beta.9';
+const STRATEGY_VERSION = '1.4.0-beta.10';
 
 const DEBUG = new URLSearchParams(window.location.search).has('s42_debug');
 const T0 = performance.now();


### PR DESCRIPTION
Version 1.4.0-beta.10 (package.json + `STRATEGY_VERSION` + Lock) und CHANGELOG-Eintrag für #342 (Kamera-Live-Toggle opt-in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)