### PR TITLE
chore: bump version to 1.4.0-beta.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 All notable changes to this project will be documented in this file.  
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-A list of unreleased changes can be found [here](https://github.com/TheRealSimon42/simon42-dashboard-strategy/compare/v1.4.0-beta.11...HEAD).
+A list of unreleased changes can be found [here](https://github.com/TheRealSimon42/simon42-dashboard-strategy/compare/v1.4.0-beta.12...HEAD).
+
+<a name="1.4.0-beta.12"></a>
+## [1.4.0-beta.12] - 2026-07-07 (Pre-Release)
+### Changes
+- **custom sections take complete section code** (overview + per-room): the YAML field now accepts a full section config (`type: grid` + `cards:` — exactly what HA's raw editor shows), and section-level options pass straight through, notably runtime `visibility` (hides the section including its heading when the condition is not met) and `column_span`. The heading is a regular `heading` card inside the YAML; the separate heading/icon editor fields are gone. Pasting a single card or a list of cards still works (auto-wrapped into a grid section), and configs created before beta.12 keep rendering unchanged via the legacy path ([#351](https://github.com/TheRealSimon42/simon42-dashboard-strategy/pull/351))
 
 <a name="1.4.0-beta.11"></a>
 ## [1.4.0-beta.11] - 2026-07-07 (Pre-Release)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simon42-dashboard-strategy",
-  "version": "1.4.0-beta.11",
+  "version": "1.4.0-beta.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simon42-dashboard-strategy",
-      "version": "1.4.0-beta.11",
+      "version": "1.4.0-beta.12",
       "dependencies": {
         "js-yaml": "^4.1.0",
         "lit": "^3.3.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simon42-dashboard-strategy",
-  "version": "1.4.0-beta.11",
+  "version": "1.4.0-beta.12",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/simon42-dashboard-strategy.ts
+++ b/src/simon42-dashboard-strategy.ts
@@ -10,7 +10,7 @@ import type { HomeAssistant } from './types/homeassistant';
 import type { Simon42StrategyConfig } from './types/strategy';
 import type { LovelaceConfig, LovelaceViewConfig } from './types/lovelace';
 
-const STRATEGY_VERSION = '1.4.0-beta.11';
+const STRATEGY_VERSION = '1.4.0-beta.12';
 
 const DEBUG = new URLSearchParams(window.location.search).has('s42_debug');
 const T0 = performance.now();


### PR DESCRIPTION
Version bump für das beta.12-Release: Custom Sections nehmen kompletten Section-Code entgegen (#351). package.json + STRATEGY_VERSION + Lockfile + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)