### PR TITLE
feat(editor): collapsible panels with icons and remembered state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,11 +41,15 @@ src/
 │   ├── SecurityViewStrategy.ts      #   Security overview (locks, doors, windows, garages, smoke/gas detectors)
 │   ├── BatteriesViewStrategy.ts     #   Battery status (critical/low/ok)
 │   └── ClimateViewStrategy.ts       #   Climate/thermostat overview (heating/cooling/idle/off)
-└── editor/                          # Configuration UI
-    ├── StrategyEditor.ts            #   Editor class (largest file — config form, state management)
-    ├── editor-handlers.ts           #   Event listeners, drag/drop area reordering
-    ├── editor-template.ts           #   HTML template generation
-    └── editor-styles.ts             #   CSS styling
+└── editor/                          # Configuration UI (module split, #355)
+    ├── StrategyEditor.ts            #   Host element: state, config plumbing, render() skeleton
+    ├── editor-host.ts               #   StrategyEditorHost interface — the contract panels program against
+    ├── editor-styles.ts             #   CSS styling
+    ├── entity-options.ts            #   Pure entity-picker helpers (+ stateFor())
+    └── panels/                      #   One module per panel: renderX(host) functions
+        ├── panel-shell.ts           #   Collapsible card shell w/ icon header + localStorage state (#354)
+        ├── AreasPanel.ts            #   Per-area editor (largest; incl. entity cache + area helpers)
+        └── *.ts                     #   Overview, Summaries, SectionOrder, StackOrder, Favorites, ...
 ```
 
 Output:
@@ -178,7 +182,13 @@ npm run watch       # Dev + auto-rebuild on file changes
 - No dynamic `obj[variable]` lookups on config objects — use `Map`/`Reflect.get` (detect-object-injection). **`hass.states[someVar]` in new/changed lines counts too** — use the `stateFor()`/`Reflect.get` helpers.
 - **Always bind the catch parameter in async functions**: `catch (error: unknown)` — Codacy's security-node rule doesn't know optional catch binding (`catch {`).
 - Codacy's API can report ghost findings pinned to lines that no longer block the quality gate — when a finding looks inexplicable, check the PR check status first instead of contorting the code.
-- Findings without auth: `https://app.codacy.com/api/v3/analysis/organizations/gh/TheRealSimon42/repositories/simon42-dashboard-strategy/pull-requests/<N>/issues`
+- **The quality gate is `issueThreshold: 0`** — EVERY new finding blocks, Warning severity included, and **moved lines count as new lines** (refactor PRs get fully rescanned). Budget for this before large moves.
+- **Reproduce the type-aware rules locally instead of API whack-a-mole:** temporary eslint flat config with `parserOptions.project` enabling `@typescript-eslint/no-unnecessary-condition` + `no-non-null-assertion`, run on the touched files. One pass finds everything (the PR-issues API paginates at 100 and hides findings).
+- **Record-type lookups lie** (`tsconfig` has no `noUncheckedIndexedAccess`): `no-unnecessary-condition` demands removing `?.` on `Record` values that CAN be absent at runtime (e.g. `groups_options.badges`). Do NOT drop the guard — rewrite as `Reflect.get(obj, key) as T | undefined` so the condition stays type-honest. Only drop `?.`/fallbacks where the API really guarantees presence (`hass.states[x].attributes`, `hass.areas/devices/entities`, `EntityRegistryEntry.labels` — HA floor 2024.7).
+- Array index access `arr[i]` also triggers detect-object-injection — use `arr.at(i)` (lib ES2022) + `splice(i, 1, next)` for writes.
+- `xss/no-mixed-html` and `@typescript-eslint/no-confusing-void-expression` are file-level disabled in `src/editor/**` (mass false positives on lit-html / house-style event arrows); a no-op stub plugin in `eslint.config.mjs` keeps the directives valid locally. The `.codacy.yml` engine switch (adopted from oriel-dashboard) is currently NOT honored by our Codacy setup — disabling the legacy ESLint8 engine in the Codacy UI would supersede the inline disables.
+- Semgrep flags `yaml.load()` as RCE — false positive for js-yaml v4 (safe schema by default); suppress with `// nosemgrep` on the call line.
+- Findings without auth: `https://app.codacy.com/api/v3/analysis/organizations/gh/TheRealSimon42/repositories/simon42-dashboard-strategy/pull-requests/<N>/issues` (paginated via `cursor`!)
 
 ## Git & Release Workflow
 

--- a/src/editor/StrategyEditor.ts
+++ b/src/editor/StrategyEditor.ts
@@ -41,6 +41,11 @@ import {
 import { renderSectionOrderPanel } from './panels/SectionOrderPanel';
 import { renderSummariesSection } from './panels/SummariesPanel';
 import { renderAreasSection, areaOptionsFor } from './panels/AreasPanel';
+import {
+  renderCollapsiblePanel,
+  loadExpandedPanels,
+  type PanelMeta,
+} from './panels/panel-shell';
 import { mergeStacksOrder } from '../utils/name-utils';
 
 // -- Supporting types for the editor ------------------------------------
@@ -51,6 +56,25 @@ declare global {
     cardTools?: unknown;
   }
 }
+
+const ASSETS = 'https://github.com/TheRealSimon42/simon42-dashboard-strategy/blob/main/assets';
+
+/** Header meta for the collapsible panels. Keys are persisted — keep stable. */
+const PANELS: Record<string, PanelMeta> = {
+  overview: { key: 'overview', icon: 'mdi:view-dashboard-outline', labelKey: 'editor.section_overview' },
+  summaries: { key: 'summaries', icon: 'mdi:counter', labelKey: 'editor.section_summaries' },
+  favorites: { key: 'favorites', icon: 'mdi:star-outline', labelKey: 'editor.section_favorites' },
+  light_favorites: { key: 'light_favorites', icon: 'mdi:lightbulb-on-outline', labelKey: 'editor.section_light_favorites' },
+  areas: { key: 'areas', icon: 'mdi:floor-plan', labelKey: 'editor.section_areas' },
+  room_pins: { key: 'room_pins', icon: 'mdi:pin-outline', labelKey: 'editor.section_room_pins' },
+  views: { key: 'views', icon: 'mdi:tab', labelKey: 'editor.section_views' },
+  section_order: { key: 'section_order', icon: 'mdi:sort', labelKey: 'editor.section_order' },
+  weather_sensors: { key: 'weather_sensors', icon: 'mdi:weather-partly-cloudy', labelKey: 'editor.section_weather_sensors' },
+  custom_cards: { key: 'custom_cards', icon: 'mdi:card-plus-outline', labelKey: 'editor.section_custom_cards', tutorialUrl: `${ASSETS}/Eigene-Karten-hinzufugen.gif` },
+  custom_sections: { key: 'custom_sections', icon: 'mdi:view-grid-plus-outline', labelKey: 'editor.section_custom_sections' },
+  custom_badges: { key: 'custom_badges', icon: 'mdi:label-outline', labelKey: 'editor.section_custom_badges', tutorialUrl: `${ASSETS}/Custom-Badges-hinzufugen.gif` },
+  custom_views: { key: 'custom_views', icon: 'mdi:tab-plus', labelKey: 'editor.section_custom_views', tutorialUrl: `${ASSETS}/Custom-View-hinzufugen.gif` },
+};
 
 // ====================================================================
 // Editor Class
@@ -69,6 +93,7 @@ class Simon42DashboardStrategyEditor extends LitElement implements StrategyEdito
 
   _config: Simon42StrategyConfig = {};
   _expandedAreas = new Set<string>();
+  _expandedPanels = loadExpandedPanels();
   _expandedGroups = new Map<string, Set<string>>();
 
   // Entity search state (NOT @state — we call requestUpdate manually)
@@ -112,10 +137,10 @@ class Simon42DashboardStrategyEditor extends LitElement implements StrategyEdito
 
     return html`
       <div class="card-config">
-        ${renderOverviewSection(this)}
-        ${renderSummariesSection(this)}
-        ${renderFavoritesSection(this)}
-        ${renderLightFavoritesSection(this)}
+        ${renderCollapsiblePanel(this, PANELS.overview, () => renderOverviewSection(this))}
+        ${renderCollapsiblePanel(this, PANELS.summaries, () => renderSummariesSection(this))}
+        ${renderCollapsiblePanel(this, PANELS.favorites, () => renderFavoritesSection(this))}
+        ${renderCollapsiblePanel(this, PANELS.light_favorites, () => renderLightFavoritesSection(this))}
 
         <div class="section-divider">
           <div class="section-divider-title">
@@ -123,9 +148,9 @@ class Simon42DashboardStrategyEditor extends LitElement implements StrategyEdito
           </div>
         </div>
 
-        ${renderAreasSection(this)}
-        ${renderRoomPinsSection(this)}
-        ${renderViewsSection(this)}
+        ${renderCollapsiblePanel(this, PANELS.areas, () => renderAreasSection(this))}
+        ${renderCollapsiblePanel(this, PANELS.room_pins, () => renderRoomPinsSection(this))}
+        ${renderCollapsiblePanel(this, PANELS.views, () => renderViewsSection(this))}
 
         <div class="section-divider">
           <div class="section-divider-title">
@@ -133,12 +158,12 @@ class Simon42DashboardStrategyEditor extends LitElement implements StrategyEdito
           </div>
         </div>
 
-        ${renderSectionOrderPanel(this)}
-        ${renderWeatherSensorsSection(this)}
-        ${renderCustomCardsSection(this)}
-        ${renderCustomSectionsSection(this)}
-        ${renderCustomBadgesSection(this)}
-        ${renderCustomViewsSection(this)}
+        ${renderCollapsiblePanel(this, PANELS.section_order, () => renderSectionOrderPanel(this))}
+        ${renderCollapsiblePanel(this, PANELS.weather_sensors, () => renderWeatherSensorsSection(this))}
+        ${renderCollapsiblePanel(this, PANELS.custom_cards, () => renderCustomCardsSection(this))}
+        ${renderCollapsiblePanel(this, PANELS.custom_sections, () => renderCustomSectionsSection(this))}
+        ${renderCollapsiblePanel(this, PANELS.custom_badges, () => renderCustomBadgesSection(this))}
+        ${renderCollapsiblePanel(this, PANELS.custom_views, () => renderCustomViewsSection(this))}
       </div>
     `;
   }

--- a/src/editor/editor-host.ts
+++ b/src/editor/editor-host.ts
@@ -38,6 +38,8 @@ export interface StrategyEditorHost {
   _config: Simon42StrategyConfig;
 
   // -- Reactive UI state --------------------------------------------------
+  /** Expanded editor panels (persisted via panels/panel-shell.ts). */
+  _expandedPanels: Set<string>;
   _expandedAreas: Set<string>;
   _expandedGroups: Map<string, Set<string>>;
 

--- a/src/editor/editor-styles.ts
+++ b/src/editor/editor-styles.ts
@@ -23,6 +23,59 @@ export const EDITOR_STYLES = css`
     padding: 16px;
     transition: box-shadow 0.2s ease;
   }
+  /* -- Collapsible panel shell (#354) --------------------------------- */
+  .section.panel {
+    padding: 0;
+    overflow: hidden;
+  }
+  .panel-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    padding: 13px 16px;
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 15px;
+    font-weight: 500;
+    color: var(--primary-text-color);
+    text-align: left;
+    letter-spacing: 0.01em;
+  }
+  .panel-header:hover {
+    background: var(--secondary-background-color, rgba(0, 0, 0, 0.04));
+  }
+  .panel-icon {
+    --mdc-icon-size: 20px;
+    color: var(--primary-color);
+    flex-shrink: 0;
+  }
+  .panel-title {
+    flex: 1;
+    min-width: 0;
+  }
+  .panel-tutorial {
+    color: var(--primary-color);
+    text-decoration: none;
+    font-size: 18px;
+    line-height: 1;
+  }
+  .panel-chevron {
+    --mdc-icon-size: 22px;
+    color: var(--secondary-text-color);
+    transition: transform 0.2s ease;
+    flex-shrink: 0;
+  }
+  .panel.collapsed .panel-chevron {
+    transform: rotate(-90deg);
+  }
+  .panel-body {
+    padding: 12px 16px 16px;
+    border-top: 1px solid var(--divider-color, #e8e8e8);
+  }
+
   .section-title {
     font-size: 15px;
     font-weight: 500;

--- a/src/editor/panels/AreasPanel.ts
+++ b/src/editor/panels/AreasPanel.ts
@@ -70,8 +70,6 @@ export function renderAreasSection(host: StrategyEditorHost): TemplateResult {
   const navItems = host._config.areas_display?.nav_items || [];
 
   return html`
-    <div class="section">
-      <div class="section-title">${localize('editor.section_areas')}</div>
 
       ${host._renderCheckbox('group-by-floors', localize('editor.group_by_floors'), groupByFloors,
         (checked) => host._toggleChanged('group_by_floors', checked, false))}
@@ -188,7 +186,6 @@ export function renderAreasSection(host: StrategyEditorHost): TemplateResult {
           })}
         </div>
       </details>
-    </div>
   `;
 }
 

--- a/src/editor/panels/CustomConfigPanels.ts
+++ b/src/editor/panels/CustomConfigPanels.ts
@@ -36,14 +36,6 @@ export function renderCustomCardsSection(host: StrategyEditorHost): TemplateResu
   const customCardsIcon = host._config.custom_cards_icon || '';
 
   return html`
-    <div class="section">
-      <div class="section-title" style="display: flex; align-items: center; gap: 8px;">
-        ${localize('editor.section_custom_cards')}
-        <a href="https://github.com/TheRealSimon42/simon42-dashboard-strategy/blob/main/assets/Eigene-Karten-hinzufugen.gif"
-          target="_blank" rel="noopener"
-          style="color: var(--primary-color); text-decoration: none; font-size: 18px;"
-          title=${localize('editor.video_tutorial')}>&#x1F3AC;</a>
-      </div>
       <div class="custom-item-row" style="margin-bottom: 12px;">
         <input type="text" id="custom-cards-heading"
           .value=${customCardsHeading}
@@ -68,7 +60,6 @@ export function renderCustomCardsSection(host: StrategyEditorHost): TemplateResu
         ${localize('editor.add_custom_card')}
       </button>
       <div class="description">${localize('editor.custom_cards_help')}</div>
-    </div>
   `;
 }
 
@@ -216,14 +207,6 @@ export function renderCustomBadgesSection(host: StrategyEditorHost): TemplateRes
   const customBadges = host._config.custom_badges || [];
 
   return html`
-    <div class="section">
-      <div class="section-title" style="display: flex; align-items: center; gap: 8px;">
-        ${localize('editor.section_custom_badges')}
-        <a href="https://github.com/TheRealSimon42/simon42-dashboard-strategy/blob/main/assets/Custom-Badges-hinzufugen.gif"
-          target="_blank" rel="noopener"
-          style="color: var(--primary-color); text-decoration: none; font-size: 18px;"
-          title=${localize('editor.video_tutorial')}>&#x1F3AC;</a>
-      </div>
 
       <div id="custom-badges-list">
         ${customBadges.length === 0
@@ -235,7 +218,6 @@ export function renderCustomBadgesSection(host: StrategyEditorHost): TemplateRes
         ${localize('editor.add_custom_badge')}
       </button>
       <div class="description">${localize('editor.custom_badges_help')}</div>
-    </div>
   `;
 }
 
@@ -327,14 +309,6 @@ export function renderCustomViewsSection(host: StrategyEditorHost): TemplateResu
   const customViews = host._config.custom_views || [];
 
   return html`
-    <div class="section">
-      <div class="section-title" style="display: flex; align-items: center; gap: 8px;">
-        ${localize('editor.section_custom_views')}
-        <a href="https://github.com/TheRealSimon42/simon42-dashboard-strategy/blob/main/assets/Custom-View-hinzufugen.gif"
-          target="_blank" rel="noopener"
-          style="color: var(--primary-color); text-decoration: none; font-size: 18px;"
-          title=${localize('editor.video_tutorial')}>&#x1F3AC;</a>
-      </div>
 
       <div id="custom-views-list">
         ${customViews.length === 0
@@ -346,7 +320,6 @@ export function renderCustomViewsSection(host: StrategyEditorHost): TemplateResu
         ${localize('editor.add_custom_view')}
       </button>
       <div class="description">${localize('editor.custom_views_help')}</div>
-    </div>
   `;
 }
 
@@ -469,8 +442,6 @@ export function renderCustomSectionsSection(host: StrategyEditorHost): TemplateR
   const customSections = host._config.custom_sections || [];
 
   return html`
-    <div class="section">
-      <div class="section-title">${localize('editor.section_custom_sections')}</div>
       <div class="description" style="margin-bottom: 8px;">${localize('editor.custom_sections_desc')}</div>
 
       <div id="custom-sections-list">
@@ -483,7 +454,6 @@ export function renderCustomSectionsSection(host: StrategyEditorHost): TemplateR
         ${localize('editor.add_custom_section')}
       </button>
       <div class="description">${localize('editor.custom_sections_help')}</div>
-    </div>
   `;
 }
 

--- a/src/editor/panels/FavoritesPanel.ts
+++ b/src/editor/panels/FavoritesPanel.ts
@@ -31,8 +31,6 @@ export function renderLightFavoritesSection(host: StrategyEditorHost): TemplateR
   const entityMap = new Map(allEntities.map((e) => [e.entity_id, e.name]));
   const filtered = getFilteredEntities(host._hass, host._lightFavSearch).filter((e) => e.entity_id.startsWith('light.'));
   return html`
-    <div class="section">
-      <div class="section-title">${localize('editor.section_light_favorites')}</div>
 
       ${lightFavs.length > 0 ? html`
         <div class="entity-list-container" style="margin-bottom: 8px;">
@@ -73,7 +71,6 @@ export function renderLightFavoritesSection(host: StrategyEditorHost): TemplateR
         ` : nothing}
       </div>
       <div class="description">${localize('editor.light_favorites_desc')}</div>
-    </div>
   `;
 }
 
@@ -105,8 +102,6 @@ export function renderFavoritesSection(host: StrategyEditorHost): TemplateResult
   const filteredEntities = getFilteredEntities(host._hass, host._favoriteSearch);
 
   return html`
-    <div class="section">
-      <div class="section-title">${localize('editor.section_favorites')}</div>
 
       <div id="favorites-list" style="margin-bottom: 12px;">
         ${favoriteEntities.length === 0
@@ -164,7 +159,6 @@ export function renderFavoritesSection(host: StrategyEditorHost): TemplateResult
 
       ${host._renderCheckbox('favorites-hide-last-changed', localize('editor.hide_last_changed'), favoritesHideLastChanged,
         (checked) => host._toggleChanged('favorites_hide_last_changed', checked, false))}
-    </div>
   `;
 }
 

--- a/src/editor/panels/OverviewPanel.ts
+++ b/src/editor/panels/OverviewPanel.ts
@@ -28,8 +28,6 @@ export function renderOverviewSection(host: StrategyEditorHost): TemplateResult 
   const alarmEntities = getAlarmEntities(host._hass);
 
   return html`
-    <div class="section">
-      <div class="section-title">${localize('editor.section_overview')}</div>
 
       ${host._renderCheckbox('show-clock-card', localize('editor.show_clock_card'), showClockCard,
         (checked) => host._toggleChanged('show_clock_card', checked, true))}
@@ -102,7 +100,6 @@ export function renderOverviewSection(host: StrategyEditorHost): TemplateResult 
           })}
         </div>
       ` : nothing}
-    </div>
   `;
 }
 

--- a/src/editor/panels/RoomPinsPanel.ts
+++ b/src/editor/panels/RoomPinsPanel.ts
@@ -41,8 +41,6 @@ export function renderRoomPinsSection(host: StrategyEditorHost): TemplateResult 
   const filteredEntities = getFilteredEntities(host._hass, host._roomPinSearch, true);
 
   return html`
-    <div class="section">
-      <div class="section-title">${localize('editor.section_room_pins')}</div>
 
       <div id="room-pins-list" style="margin-bottom: 12px;">
         ${roomPinEntities.length === 0
@@ -108,7 +106,6 @@ export function renderRoomPinsSection(host: StrategyEditorHost): TemplateResult 
 
       ${host._renderCheckbox('room-pins-first', localize('editor.room_pins_first'), roomPinsFirst,
         (checked) => host._toggleChanged('room_pins_first', checked, false))}
-    </div>
   `;
 }
 

--- a/src/editor/panels/SectionOrderPanel.ts
+++ b/src/editor/panels/SectionOrderPanel.ts
@@ -97,8 +97,6 @@ export function renderSectionOrderPanel(host: StrategyEditorHost): TemplateResul
   const powerSensorEntities = getPowerSensorEntities(host._hass);
 
   return html`
-    <div class="section">
-      <div class="section-title">${localize('editor.section_order')}</div>
       <div class="description" style="margin-left: 0; margin-bottom: 12px;">
         ${localize('editor.section_order_desc')}
       </div>
@@ -217,6 +215,11 @@ export function renderSectionOrderPanel(host: StrategyEditorHost): TemplateResul
               <label for="hide-heading-${hk}">${localize('editor.heading_label_' + hk)}</label>
             </div>
           `)}
+        </div>
+      </details>
+
+      <details style="margin-top: 12px;">
+        <summary style="cursor: pointer; font-size: 13px; font-weight: 500; color: var(--primary-text-color); padding: 4px 0;">
           ${localize('editor.section_visibility')}
         </summary>
         <div style="margin-left: 14px; margin-top: 6px;">
@@ -269,7 +272,6 @@ export function renderSectionOrderPanel(host: StrategyEditorHost): TemplateResul
           (checked) => host._toggleChanged('show_updates_badge', checked, false))}
         <div class="description">${localize('editor.show_updates_badge_desc')}</div>
       </div>
-    </div>
   `;
 }
 

--- a/src/editor/panels/SummariesPanel.ts
+++ b/src/editor/panels/SummariesPanel.ts
@@ -41,8 +41,6 @@ export function renderSummariesSection(host: StrategyEditorHost): TemplateResult
   const unavailableBatteriesBucket = host._config.unavailable_batteries_bucket === 'critical' ? 'critical' : 'good';
 
   return html`
-    <div class="section">
-      <div class="section-title">${localize('editor.section_summaries')}</div>
 
       <div class="form-row">
         <input type="radio" id="summaries-2-columns" name="summaries-columns" value="2"
@@ -205,7 +203,6 @@ export function renderSummariesSection(host: StrategyEditorHost): TemplateResult
           ${renderMaintenanceUsersPicker(host)}
         </div>
       ` : nothing}
-    </div>
   `;
 }
 

--- a/src/editor/panels/ViewsPanel.ts
+++ b/src/editor/panels/ViewsPanel.ts
@@ -19,8 +19,6 @@ export function renderViewsSection(host: StrategyEditorHost): TemplateResult {
   const showRoomViews = host._config.show_room_views === true;
 
   return html`
-    <div class="section">
-      <div class="section-title">${localize('editor.section_views')}</div>
 
       ${host._renderCheckbox('show-summary-views', localize('editor.show_summary_views'), showSummaryViews,
         (checked) => host._toggleChanged('show_summary_views', checked, false))}
@@ -29,6 +27,5 @@ export function renderViewsSection(host: StrategyEditorHost): TemplateResult {
       ${host._renderCheckbox('show-room-views', localize('editor.show_room_views'), showRoomViews,
         (checked) => host._toggleChanged('show_room_views', checked, false))}
       <div class="description">${localize('editor.show_room_views_desc')}</div>
-    </div>
   `;
 }

--- a/src/editor/panels/WeatherSensorsPanel.ts
+++ b/src/editor/panels/WeatherSensorsPanel.ts
@@ -34,8 +34,6 @@ export function renderWeatherSensorsSection(host: StrategyEditorHost): TemplateR
   const filteredEntities = getFilteredEntities(host._hass, host._weatherSensorSearch);
 
   return html`
-    <div class="section">
-      <div class="section-title">${localize('editor.section_weather_sensors')}</div>
       <div class="description" style="margin-left: 0; margin-bottom: 12px;">
         ${localize('editor.weather_sensors_desc')}
       </div>
@@ -98,7 +96,6 @@ export function renderWeatherSensorsSection(host: StrategyEditorHost): TemplateR
           </div>
         ` : nothing}
       </div>
-    </div>
   `;
 }
 

--- a/src/editor/panels/panel-shell.ts
+++ b/src/editor/panels/panel-shell.ts
@@ -1,0 +1,94 @@
+// ====================================================================
+// SIMON42 DASHBOARD STRATEGY - EDITOR: COLLAPSIBLE PANEL SHELL
+// ====================================================================
+// Wraps every editor panel in a collapsible card with an icon header
+// (visual anchor while scrolling, see #354). The expanded/collapsed
+// state persists per browser in localStorage; panels absent from the
+// stored set default to collapsed, so newly added panels start tidy.
+// A collapsed panel's body is not rendered at all — panels with
+// expensive bodies (areas) cost nothing while closed.
+// ====================================================================
+
+import { html, nothing, type TemplateResult } from 'lit';
+import { localize } from '../../utils/localize';
+import type { StrategyEditorHost } from '../editor-host';
+
+export interface PanelMeta {
+  /** Stable key used for state persistence — never change once shipped. */
+  key: string;
+  /** MDI icon shown in the header. */
+  icon: string;
+  /** i18n key for the header label (reuses the former section titles). */
+  labelKey: string;
+  /** Optional video-tutorial GIF link shown in the header. */
+  tutorialUrl?: string;
+}
+
+const STORAGE_KEY = 's42-editor-expanded-panels';
+
+/** Load the persisted set of expanded panel keys (empty = all collapsed). */
+export function loadExpandedPanels(): Set<string> {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return new Set();
+    const parsed: unknown = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return new Set(parsed.filter((k): k is string => typeof k === 'string'));
+    }
+  } catch {
+    // Private mode / storage disabled — fall back to session-only state
+  }
+  return new Set();
+}
+
+function persistExpandedPanels(expanded: Set<string>): void {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify([...expanded]));
+  } catch {
+    // Private mode / storage disabled — state stays session-only
+  }
+}
+
+function togglePanel(host: StrategyEditorHost, key: string): void {
+  if (host._expandedPanels.has(key)) {
+    host._expandedPanels.delete(key);
+  } else {
+    host._expandedPanels.add(key);
+  }
+  persistExpandedPanels(host._expandedPanels);
+  host.requestUpdate();
+}
+
+export function renderCollapsiblePanel(
+  host: StrategyEditorHost,
+  meta: PanelMeta,
+  body: () => TemplateResult,
+): TemplateResult {
+  const expanded = host._expandedPanels.has(meta.key);
+
+  return html`
+    <div class="section panel${expanded ? '' : ' collapsed'}">
+      <button
+        type="button"
+        class="panel-header"
+        aria-expanded=${expanded ? 'true' : 'false'}
+        @click=${() => togglePanel(host, meta.key)}
+      >
+        <ha-icon class="panel-icon" icon=${meta.icon}></ha-icon>
+        <span class="panel-title">${localize(meta.labelKey)}</span>
+        ${meta.tutorialUrl
+          ? html`<a
+              href=${meta.tutorialUrl}
+              target="_blank"
+              rel="noopener"
+              class="panel-tutorial"
+              title=${localize('editor.video_tutorial')}
+              @click=${(e: Event) => { e.stopPropagation(); }}
+            >&#x1F3AC;</a>`
+          : nothing}
+        <ha-icon class="panel-chevron" icon="mdi:chevron-down"></ha-icon>
+      </button>
+      ${expanded ? html`<div class="panel-body">${body()}</div>` : nothing}
+    </div>
+  `;
+}

--- a/src/editor/panels/panel-shell.ts
+++ b/src/editor/panels/panel-shell.ts
@@ -9,6 +9,12 @@
 // expensive bodies (areas) cost nothing while closed.
 // ====================================================================
 
+/* eslint-disable xss/no-mixed-html, @typescript-eslint/no-confusing-void-expression --
+   False positive: lit-html's `html` tag escapes every interpolation by
+   construction. Codacy's legacy ESLint 8 engine misreads lit render
+   functions, DOM Element locals and input event payloads as raw HTML. The
+   void-expression rule fights the codebase's established concise event-
+   handler arrows (`(checked) => host._toggleChanged(...)`). */
 import { html, nothing, type TemplateResult } from 'lit';
 import { localize } from '../../utils/localize';
 import type { StrategyEditorHost } from '../editor-host';


### PR DESCRIPTION
Closes #354 — danke @a7rk für den Vorschlag inklusive der Beobachtung, dass beim Scrollen visuelle Anker fehlen.

## Was sich ändert

Alle 13 Einstellungs-Bereiche des Editors sind jetzt **einklappbare Karten mit Icon-Header**:

- **Icon pro Bereich** (farbig, MDI) — die visuellen Anker aus #354: man erkennt beim Scrollen sofort, wo man ist
- **Zustand wird gemerkt**: Die aufgeklappten Panels landen in `localStorage` (pro Browser). Wer gerade eigene Sections baut, lässt genau dieses Panel offen — alles andere bleibt zu, auch nach Editor-Neuöffnen. Kein 7-Meter-Scrollen mehr
- **Start-Zustand: alles zugeklappt** — der Editor zeigt sich erstmals als kompakte Übersicht. Neue Panels künftiger Releases starten automatisch ebenfalls zugeklappt (gespeichert wird das Aufgeklappte)
- Die 🎬-Tutorial-Links (Eigene Karten/Badges/Views) sind in die Header gewandert
- **Perf-Bonus:** Zugeklappte Panels rendern ihren Inhalt gar nicht — insbesondere das Bereichs-Panel kostet nichts mehr, solange es geschlossen ist

Technisch: neue `panels/panel-shell.ts` (Header + Toggle + Persistenz via `s42-editor-expanded-panels`), die Panels geben nur noch ihren Inhalt aus — die Karte samt Titel stellt die Shell. Baut direkt auf dem Modul-Split aus #355 auf.

## Nebenbei gefixt

Verwaister `</summary>`-Tag im Abschnitts-Panel (seit #329): „Abschnittsüberschriften ausblenden" und „Bedingte Sichtbarkeit" waren ungewollt EIN Aufklapp-Block mit frei schwebendem Label-Text — jetzt wieder zwei saubere `<details>`-Blöcke.

Außerdem: CLAUDE.md um die Codacy-Lehren aus #355 und den aktuellen Editor-Modulbaum ergänzt.

## Verifikation

- tsc, ESLint (0 Warnungen), 129/129 Tests, Build grün
- Live getestet auf Prod (HA 2026.7): Auf-/Zuklappen, Zustand überlebt Editor-Neuöffnen, 🎬-Links togglen nicht, beide details-Blöcke im Abschnitts-Panel funktionieren

**Hinweis:** Dies ist der erste `feat:`-Merge seit der release-please-Umstellung (#353) — nach dem Merge sollte `simon42-release-bot` automatisch den Release-PR für v1.4.0-beta.13 öffnen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
