### PR TITLE
ci: unshallow the main fetch in release-build's ancestor check

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -49,8 +49,11 @@ jobs:
           fetch-depth: 0
 
       - name: Ensure release commit is on main
+        # Full fetch: a shallow tip (--depth=1) breaks merge-base when main
+        # has moved past the tagged commit (e.g. a follow-up merge landed
+        # between tagging and this build).
         run: |
-          git fetch origin main --depth=1
+          git fetch origin main
           git merge-base --is-ancestor HEAD origin/main
 
       - name: Setup Node


### PR DESCRIPTION
Der Reparatur-Dispatch für beta.13 scheiterte am Wächter-Step: `git fetch origin main --depth=1` liefert nur die Spitze, und sobald main am Tag vorbeigewandert ist (hier: der #359-Merge zwischen Tagging und Build), kann `merge-base --is-ancestor` die Historie nicht verbinden. Voller Fetch löst das; der Checkout ist ohnehin `fetch-depth: 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)