### PR TITLE
Fix clipped entity picker dropdowns in editor panels

### DIFF
--- a/src/editor/editor-styles.ts
+++ b/src/editor/editor-styles.ts
@@ -26,6 +26,9 @@ export const EDITOR_STYLES = css`
   /* -- Collapsible panel shell (#354) --------------------------------- */
   .section.panel {
     padding: 0;
+    overflow: visible;
+  }
+  .section.panel.collapsed {
     overflow: hidden;
   }
   .panel-header {

--- a/tests/editor/editor-styles.test.ts
+++ b/tests/editor/editor-styles.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+
+import { EDITOR_STYLES } from '../../src/editor/editor-styles';
+
+describe('editor panel styles', () => {
+  it('allows expanded picker overlays to escape panel boundaries', () => {
+    expect(EDITOR_STYLES.cssText).toMatch(/\.section\.panel\s*{[^}]*overflow:\s*visible;/s);
+    expect(EDITOR_STYLES.cssText).toMatch(/\.section\.panel\.collapsed\s*{[^}]*overflow:\s*hidden;/s);
+  });
+});


### PR DESCRIPTION
## Summary

- allow entity-picker result overlays to extend beyond expanded editor panels
- keep overflow clipping for collapsed panels
- add a regression test for both panel states

## Root cause

The collapsible panel shell introduced `overflow: hidden` for every panel. Entity search results are positioned as an overlay, so an expanded panel clipped the dropdown at its lower boundary and made the choices appear to disappear.

## Validation

- `npm test` (130 tests)
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`
- `git diff --check`

Fixes #362
