### PR TITLE
fix: prefer live view camera in per-device dedup (Ring doorbells)

### DIFF
--- a/src/views/CctvViewStrategy.ts
+++ b/src/views/CctvViewStrategy.ts
@@ -46,6 +46,13 @@ const REOLINK_STREAM_PREFERENCE = [
   'snapshots_main',
 ];
 
+// -- Camera stream preference (other integrations) ----------------------
+// Ring exposes two camera entities per doorbell/cam: the live stream
+// (translation_key 'live_view') and a 'last_recording' snapshot camera.
+// Without a preference the per-device dedup keeps whichever entity the
+// registry lists first — which can silently drop the live view (#378).
+const LIVE_STREAM_PREFERENCE = ['live_view'];
+
 // -- PTZ pad ------------------------------------------------------------
 // Reolink button translation_keys (homeassistant/components/reolink/button.py).
 // Only buttons that actually exist on the device are rendered.
@@ -251,7 +258,7 @@ function isVisibleWithState(entityId: string, hass: HomeAssistant): boolean {
 }
 
 function pickPrimaryCamera(cameraIds: string[]): string {
-  for (const preferredKey of REOLINK_STREAM_PREFERENCE) {
+  for (const preferredKey of [...REOLINK_STREAM_PREFERENCE, ...LIVE_STREAM_PREFERENCE]) {
     for (const id of cameraIds) {
       if (Registry.getEntity(id)?.translation_key === preferredKey) return id;
     }

--- a/tests/views/CctvViewStrategy.test.ts
+++ b/tests/views/CctvViewStrategy.test.ts
@@ -107,6 +107,33 @@ describe('collectCameraBlocks', () => {
     expect(blocks[0].isReolink).toBe(true);
   });
 
+  it('prefers the live view over the last-recording camera (Ring, #378)', () => {
+    const hass = makeHass({
+      areas: [{ area_id: 'eingang', name: 'Eingang' }],
+      devices: [
+        {
+          id: 'dev_ring',
+          area_id: 'eingang',
+          manufacturer: 'Ring',
+          model: 'Video Doorbell',
+          name: 'Haustür Klingel',
+        },
+      ],
+      entities: [
+        // last_recording deliberately listed first — without the live-view
+        // preference the dedup would keep it and drop the live stream
+        { entity_id: 'camera.haustuer_last_recording', device_id: 'dev_ring', platform: 'ring', translation_key: 'last_recording', attributes: { friendly_name: 'Haustür Letzte Aufnahme' } },
+        { entity_id: 'camera.haustuer_live_view', device_id: 'dev_ring', platform: 'ring', translation_key: 'live_view', attributes: { friendly_name: 'Haustür Live' } },
+      ],
+    });
+    initRegistry(hass);
+
+    const blocks = collectCameraBlocks(hass, {});
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].cameraId).toBe('camera.haustuer_live_view');
+    expect(blocks[0].isReolink).toBe(false);
+  });
+
   it('keeps cameras without a device as standalone blocks', () => {
     const hass = makeHass({
       entities: [


### PR DESCRIPTION
## Problem

Ring exposes two camera entities per doorbell/cam on the same device: the live stream (`translation_key: live_view`) and a "last recording" camera (`last_recording`). The per-device camera dedup (`pickPrimaryCamera`) only knew the Reolink stream keys and fell back to whichever entity the registry listed first — which could silently drop the live view from the CCTV view, the security view **and** the editor's camera picker (all three share `collectCameraBlocks`).

## Fix

`live_view` joins the stream preference (after the Reolink keys, before the arbitrary fallback). Reolink behavior is untouched — their keys still match first.

## Tests

- New unit test: Ring device with `last_recording` listed first → the `live_view` camera survives the dedup.
- Live-tested on a real HA system (Reolink cameras unchanged: one card per device, sub stream preferred).

Reproduzieren kann den Original-Fall nur ein Ring-Setup — Test-Anleitung für die Melderin:
1. Neue Version installieren, Hard-Refresh (Ctrl+Shift+R)
2. Kamera-/Sicherheits-View öffnen → erwarte die Live-Ansicht der Türklingel
3. Editor → Kamera-Auswahl → erwarte die Live-View-Kamera in der Liste

Closes #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)