### PR TITLE
feat: configurable area card pictures (compact/picture display type)

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -563,6 +563,8 @@ Die Spalte **Seit** gibt an, ab welcher Version die Option verfügbar ist. „�
 
 **Bereiche & Räume**
 
+**Bereichsfotos** *(ab v1.4.0)* — Mit `area_display_type: picture` (Dropdown im Editor) zeigen die Bereichskarten der Übersicht das in Home Assistant hinterlegte Bereichsfoto (Einstellungen → Bereiche → Bereich bearbeiten → Bild). Bereiche ohne Foto bleiben automatisch kompakt, und pro Bereich lässt sich die globale Einstellung überschreiben (`areas_options.{id}.display_type`, Dropdown im aufgeklappten Bereich).
+
 | Option | Typ | Standard | Seit | Beschreibung |
 |--------|-----|----------|------|-------------|
 | `group_by_floors` | boolean | `false` | — | Bereiche nach Etagen gliedern |


### PR DESCRIPTION
Follow-up zu #380 (Closes #379): Der Squash-Commit ist ohne Conventional-Commit-Präfix auf `main` gelandet — release-please würde das Feature daher weder im CHANGELOG führen noch ein Release auslösen. Dieser PR ergänzt die fehlende README-Nutzungsnotiz (wo hinterlegt man Bereichsfotos in HA) und trägt den Feature-Titel für die Release-Pipeline nach.

Feature-Code und Credit: #380 von @Cyberhunter88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)