### PR TITLE
fix: editor picker filtering, badge-only hiding, dual-lens cameras

### DIFF
--- a/src/Registry.ts
+++ b/src/Registry.ts
@@ -83,7 +83,11 @@ class Registry {
   /** Entities with the "no_dboard" label — excluded from all dashboard views */
   private static _excludeSet: Set<string>;
 
-  /** Entities hidden via areas_options.*.groups_options.*.hidden in config */
+  /**
+   * Entities hidden via areas_options.*.groups_options.*.hidden in config.
+   * The 'badges' pseudo-group is excluded — deselecting a badge must not
+   * hide the entity dashboard-wide (#396).
+   */
   private static _hiddenFromConfig: Set<string>;
 
   /** Initialization flag */
@@ -307,6 +311,7 @@ class Registry {
    * Exclusion pipeline (matches the JS data-collectors logic):
    * 1. no_dboard label -> _excludeSet
    * 2. areas_options.*.groups_options.*.hidden -> _hiddenFromConfig
+   *    (except the 'badges' pseudo-group, which only affects room badges)
    */
   private static _buildExclusionSets(): void {
     // no_dboard label exclusion
@@ -323,7 +328,12 @@ class Registry {
     if (areasOptions) {
       for (const areaOpts of Object.values(areasOptions)) {
         if (areaOpts.groups_options) {
-          for (const groupOpts of Object.values(areaOpts.groups_options)) {
+          for (const [groupKey, groupOpts] of Object.entries(areaOpts.groups_options)) {
+            // The 'badges' pseudo-group only deselects auto-detected room
+            // badges — it must NOT hide the entity dashboard-wide (#396).
+            // RoomViewStrategy applies badges.hidden itself when building
+            // the badge list (see applyBadgeGroupOptions).
+            if (groupKey === 'badges') continue;
             if (groupOpts.hidden && Array.isArray(groupOpts.hidden)) {
               for (const id of groupOpts.hidden) {
                 Registry._hiddenFromConfig.add(id);

--- a/src/editor/panels/AreasPanel.ts
+++ b/src/editor/panels/AreasPanel.ts
@@ -1269,6 +1269,10 @@ async function getAreaGroupedEntities(areaId: string, hass: HomeAssistant): Prom
     if (excludeLabels.includes(entity.entity_id)) continue;
     if (!stateFor(hass, entity.entity_id)) continue;
     if (entity.hidden) continue;
+    // Config/diagnostic entities never render on the dashboard (same
+    // registry-based check as Registry._isEntityVisible) — don't offer
+    // them in the picker either (#397).
+    if (entity.entity_category === 'config' || entity.entity_category === 'diagnostic') continue;
 
     const entityRegistry = Reflect.get(hass.entities, entity.entity_id) as
       EntityRegistryEntry | undefined;
@@ -1353,6 +1357,9 @@ function getAreaBadgeCandidates(areaId: string, hass: HomeAssistant, config: Sim
     if (entity.hidden) continue;
     if (entity.labels.includes('no_dboard')) continue;
     if (!stateFor(hass, entity.entity_id)) continue;
+    // Config/diagnostic entities never render as badges (same registry-based
+    // check as Registry._isEntityVisible) — don't offer them here (#397).
+    if (entity.entity_category === 'config' || entity.entity_category === 'diagnostic') continue;
 
     const domain = entity.entity_id.split('.')[0];
     const stateObj = stateFor(hass, entity.entity_id);

--- a/src/utils/badge-utils.ts
+++ b/src/utils/badge-utils.ts
@@ -5,6 +5,7 @@
 // RoomViewStrategy (runtime) and the Editor (configuration UI).
 
 import type { HomeAssistant } from '../types/homeassistant';
+import type { GroupOptions } from '../types/strategy';
 
 // -- Badge color map (device_class → HA color name) -------------------
 
@@ -98,6 +99,52 @@ export function isBadgeCandidate(
     );
   }
   return false;
+}
+
+// -- Badge group options ----------------------------------------------
+
+/** Auto-detected badge candidate before it becomes a Lovelace badge config. */
+export interface BadgeCandidate {
+  entity: string;
+  color: string;
+  showName?: boolean;
+}
+
+/**
+ * Apply the per-area 'badges' group options to the auto-detected candidates:
+ * drop deselected badges (badges.hidden) and append manually added entities
+ * (badges.additional, only when they have a state).
+ *
+ * badges.hidden is deliberately NOT part of the Registry's global exclusion
+ * set (#396) — deselecting a badge must only remove the badge, not hide the
+ * entity in other dashboard sections. This function is the single place
+ * where badges.hidden takes effect.
+ */
+export function applyBadgeGroupOptions(
+  candidates: BadgeCandidate[],
+  badgeOpts: GroupOptions | undefined,
+  hass: HomeAssistant
+): BadgeCandidate[] {
+  if (!badgeOpts) return candidates;
+  let filtered = [...candidates];
+  if (badgeOpts.hidden?.length) {
+    const hiddenSet = new Set<string>(badgeOpts.hidden);
+    filtered = filtered.filter(function notDeselected(candidate) {
+      return !hiddenSet.has(candidate.entity);
+    });
+  }
+  if (badgeOpts.additional?.length) {
+    for (const entityId of badgeOpts.additional) {
+      const hasState = Reflect.get(hass.states, entityId) !== undefined;
+      const alreadyListed = filtered.some(function sameEntity(candidate) {
+        return candidate.entity === entityId;
+      });
+      if (hasState && !alreadyListed) {
+        filtered.push({ entity: entityId, color: getColorForEntity(entityId, hass) });
+      }
+    }
+  }
+  return filtered;
 }
 
 // -- Default show_name ------------------------------------------------

--- a/src/views/CctvViewStrategy.ts
+++ b/src/views/CctvViewStrategy.ts
@@ -1,7 +1,8 @@
 // ====================================================================
 // VIEW STRATEGY — CCTV (Camera Overview)
 // ====================================================================
-// Opt-in view (show_camera_view): one block per camera DEVICE with
+// Opt-in view (show_camera_view): one block per camera DEVICE (dual-lens
+// cameras: one block per lens, see pickPrimaryCameras) with
 //  - the camera picture (picture-glance with status entities when the
 //    device provides them, picture-entity otherwise)
 //  - a spotlight tile when the device has a light entity
@@ -257,13 +258,23 @@ function isVisibleWithState(entityId: string, hass: HomeAssistant): boolean {
   return !!stateFor(hass, entityId) && !Registry.isEntityExcluded(entityId);
 }
 
-function pickPrimaryCamera(cameraIds: string[]): string {
+/**
+ * Pick the camera entities to render for one device: all entities that
+ * carry the best available translation_key. Dual-lens cameras (e.g.
+ * Reolink Omvi 3i) expose one entity PER LENS with the SAME
+ * translation_key — every lens must keep its own block (#412), while
+ * secondary streams of the same lens (main/snapshot variants) are still
+ * deduped away. Detection stays translation_key-based — never entity_id
+ * patterns (localized, unstable).
+ */
+function pickPrimaryCameras(cameraIds: string[]): string[] {
   for (const preferredKey of [...REOLINK_STREAM_PREFERENCE, ...LIVE_STREAM_PREFERENCE]) {
-    for (const id of cameraIds) {
-      if (Registry.getEntity(id)?.translation_key === preferredKey) return id;
-    }
+    const matches = cameraIds.filter(function hasPreferredKey(id) {
+      return Registry.getEntity(id)?.translation_key === preferredKey;
+    });
+    if (matches.length > 0) return matches;
   }
-  return cameraIds[0];
+  return [cameraIds[0]];
 }
 
 function cameraDisplayName(cameraId: string, hass: HomeAssistant): string {
@@ -279,7 +290,8 @@ export function cameraBlockAreaId(block: CameraBlock): string | null {
 }
 
 /**
- * Group visible cameras into one block per device (entities without a
+ * Group visible cameras into one block per device lens (normally one per
+ * device; dual-lens cameras yield one block per lens, entities without a
  * device get their own block). Cameras in areas excluded from the
  * dashboard (areas_display.hidden) are dropped — their room views don't
  * exist, so neither the security view's area links nor the exclusion
@@ -309,12 +321,14 @@ export function collectCameraBlocks(
 
   const blocks: CameraBlock[] = [];
   for (const [deviceId, ids] of byDevice) {
-    const cameraId = ids.length === 1 ? ids[0] : pickPrimaryCamera(ids);
-    blocks.push({
-      cameraId,
-      deviceId,
-      isReolink: Registry.getEntity(cameraId)?.platform === 'reolink',
-    });
+    const primaryIds = ids.length === 1 ? [ids[0]] : pickPrimaryCameras(ids);
+    for (const cameraId of primaryIds) {
+      blocks.push({
+        cameraId,
+        deviceId,
+        isReolink: Registry.getEntity(cameraId)?.platform === 'reolink',
+      });
+    }
   }
   for (const cameraId of standalone) {
     blocks.push({
@@ -478,12 +492,15 @@ export function leanCameraCard(block: CameraBlock): LovelaceCardConfig {
 
 /**
  * Build the section for one camera block. `recordingsPath` is the media
- * browser deep link (null = no recordings link). Exported for tests.
+ * browser deep link (null = no recordings link). `renderPtz` guards the
+ * per-DEVICE PTZ pad: dual-lens cameras produce two blocks on the same
+ * device, but the pad must only render once (#412). Exported for tests.
  */
 export function buildCameraSection(
   block: CameraBlock,
   hass: HomeAssistant,
-  recordingsPath: string | null
+  recordingsPath: string | null,
+  renderPtz: boolean = true
 ): LovelaceSectionConfig {
   const name = cameraDisplayName(block.cameraId, hass);
   const companions = findCompanions(block.deviceId, hass);
@@ -523,7 +540,9 @@ export function buildCameraSection(
     cards.push(buildSpotlightTile(companions.spotlight, hass));
   }
 
-  cards.push(...buildPtzCards(companions.ptz));
+  if (renderPtz) {
+    cards.push(...buildPtzCards(companions.ptz));
+  }
 
   if (recordingsPath) {
     cards.push({
@@ -636,10 +655,16 @@ export async function buildCctvSections(
   }
 
   const sections: LovelaceSectionConfig[] = [];
+  // PTZ pad and recordings link are per DEVICE — with dual-lens cameras
+  // (two blocks on one device, #412) only the first block renders them.
+  const devicesWithControls = new Set<string>();
   for (const block of blocks) {
+    const firstOfDevice = !block.deviceId || !devicesWithControls.has(block.deviceId);
+    if (block.deviceId) devicesWithControls.add(block.deviceId);
     const device = block.deviceId ? Registry.getDevice(block.deviceId) : undefined;
-    const recordingsPath = block.isReolink ? resolveRecordingsPath(device, camItems) : null;
-    sections.push(buildCameraSection(block, hass, recordingsPath));
+    const recordingsPath =
+      block.isReolink && firstOfDevice ? resolveRecordingsPath(device, camItems) : null;
+    sections.push(buildCameraSection(block, hass, recordingsPath, firstOfDevice));
   }
 
   // Opt-in even when LLM Vision is present: the llmvision-card re-fetches

--- a/src/views/RoomViewStrategy.ts
+++ b/src/views/RoomViewStrategy.ts
@@ -16,7 +16,7 @@ import { buildAreaCustomSections } from '../sections/CustomSections';
 import { Registry } from '../Registry';
 import { timeStart, timeEnd, debugLog } from '../utils/debug';
 import { localize } from '../utils/localize';
-import { BADGE_COLOR_MAP, getColorForEntity, isDefaultShowName, resolveShowName } from '../utils/badge-utils';
+import { BADGE_COLOR_MAP, applyBadgeGroupOptions, isDefaultShowName, resolveShowName, type BadgeCandidate } from '../utils/badge-utils';
 import { densePlacement } from '../utils/view-builder';
 
 // HA supported_features bitmask values
@@ -501,12 +501,6 @@ class Simon42ViewRoomStrategy extends HTMLElement {
     const badgeOpts = groupsOptions.badges;
     const hasBadgeConfig = !!badgeOpts;
 
-    interface BadgeCandidate {
-      entity: string;
-      color: string;
-      showName?: boolean;
-    }
-
     const candidates: BadgeCandidate[] = [];
     const addCandidate = (entityId: string, colorKey: string, dcOverride?: string) => {
       const dc = dcOverride || (hass.states[entityId]?.attributes?.device_class as string | undefined);
@@ -544,20 +538,10 @@ class Simon42ViewRoomStrategy extends HTMLElement {
       for (const id of sensorEntities.door) addCandidate(id, 'door', 'door');
     }
 
-    let filteredCandidates = candidates;
-    if (hasBadgeConfig) {
-      if (badgeOpts.hidden?.length) {
-        const hiddenSet = new Set<string>(badgeOpts.hidden);
-        filteredCandidates = filteredCandidates.filter((b) => !hiddenSet.has(b.entity));
-      }
-      if (badgeOpts.additional?.length) {
-        for (const entityId of badgeOpts.additional) {
-          if (hass.states[entityId] && !filteredCandidates.some((b) => b.entity === entityId)) {
-            filteredCandidates.push({ entity: entityId, color: getColorForEntity(entityId, hass) });
-          }
-        }
-      }
-    }
+    // badges.hidden / badges.additional apply ONLY here — the Registry
+    // deliberately keeps the 'badges' pseudo-group out of its global
+    // exclusion set (#396).
+    const filteredCandidates = applyBadgeGroupOptions(candidates, badgeOpts, hass);
 
     const namesVisible = hasBadgeConfig ? new Set<string>(badgeOpts.names_visible || []) : null;
     const namesHidden = hasBadgeConfig ? new Set<string>(badgeOpts.names_hidden || []) : null;

--- a/src/views/RoomViewStrategy.ts
+++ b/src/views/RoomViewStrategy.ts
@@ -654,6 +654,10 @@ class Simon42ViewRoomStrategy extends HTMLElement {
     if (roomEntities.cameras.length > 0) {
       const cameraLiveToggle = dashboardConfig.camera_live_toggle === true;
       const cameraCards: LovelaceCardConfig[] = [];
+      // Companion glance entities (spotlight, motion, siren, battery,
+      // doorbell) are per DEVICE — dual-lens cameras render two cards on
+      // the same device (#412), only the first one carries the companions.
+      const devicesWithCompanions = new Set<string>();
       for (const cameraId of roomEntities.cameras) {
         if (!hass.states[cameraId]) continue;
         const camEntity = Registry.getEntity(cameraId);
@@ -672,6 +676,8 @@ class Simon42ViewRoomStrategy extends HTMLElement {
         }
 
         if ((isReolink || isAqara) && deviceId) {
+          const firstOfDevice = !devicesWithCompanions.has(deviceId);
+          devicesWithCompanions.add(deviceId);
           const devEntities = Registry.getEntityIdsForDevice(deviceId);
           const spotlight = devEntities.find(
             (id) => id.startsWith('light.') && hass.states[id] && !Registry.isEntityExcluded(id)
@@ -709,7 +715,7 @@ class Simon42ViewRoomStrategy extends HTMLElement {
             if (doorbell) glanceEntities.push({ entity: doorbell });
           }
 
-          cameraCards.push(buildRoomCameraCard(cameraId, stripAreaName(cameraId, area, hass), cameraLiveToggle, glanceEntities, isAqara));
+          cameraCards.push(buildRoomCameraCard(cameraId, stripAreaName(cameraId, area, hass), cameraLiveToggle, firstOfDevice ? glanceEntities : [], isAqara));
         } else {
           cameraCards.push(buildRoomCameraCard(cameraId, stripAreaName(cameraId, area, hass), cameraLiveToggle));
         }

--- a/tests/Registry.test.ts
+++ b/tests/Registry.test.ts
@@ -92,3 +92,43 @@ describe('Registry.initialize', () => {
     expect(Registry.getVisibleEntitiesForArea('kitchen')).toHaveLength(0);
   });
 });
+
+describe('badges pseudo-group exclusion (#396)', () => {
+  it('does not hide a badge-deselected entity dashboard-wide', () => {
+    const hass = makeHass({
+      areas: [{ area_id: 'kitchen', name: 'Kitchen' }],
+      entities: [
+        { entity_id: 'sensor.kitchen_power', area_id: 'kitchen', attributes: { device_class: 'power', unit_of_measurement: 'W' } },
+      ],
+    });
+    const config = {
+      areas_options: {
+        kitchen: { groups_options: { badges: { hidden: ['sensor.kitchen_power'] } } },
+      },
+    };
+    Registry.initialize(hass, config);
+
+    // The entity stays visible in all other sections (e.g. the energy block)
+    expect(Registry.isHiddenByConfig('sensor.kitchen_power')).toBe(false);
+    expect(Registry.isEntityExcluded('sensor.kitchen_power')).toBe(false);
+    expect(
+      Registry.getVisibleEntitiesForArea('kitchen').map(function toId(e) { return e.entity_id; })
+    ).toEqual(['sensor.kitchen_power']);
+  });
+
+  it('keeps hiding entities deselected in regular domain groups', () => {
+    const hass = makeHass({
+      areas: [{ area_id: 'kitchen', name: 'Kitchen' }],
+      entities: [{ entity_id: 'light.kitchen', area_id: 'kitchen' }],
+    });
+    const config = {
+      areas_options: {
+        kitchen: { groups_options: { light: { hidden: ['light.kitchen'] } } },
+      },
+    };
+    Registry.initialize(hass, config);
+
+    expect(Registry.isHiddenByConfig('light.kitchen')).toBe(true);
+    expect(Registry.getVisibleEntitiesForArea('kitchen')).toHaveLength(0);
+  });
+});

--- a/tests/utils/badge-utils.test.ts
+++ b/tests/utils/badge-utils.test.ts
@@ -1,0 +1,69 @@
+// ============================================================================
+// Tests — Badge utilities (badges group options, #396)
+// ============================================================================
+// badges.hidden must keep working as the badge-only deselection now that the
+// Registry no longer folds the 'badges' pseudo-group into its global
+// exclusion set: applyBadgeGroupOptions is the single place where
+// badges.hidden and badges.additional take effect.
+// ============================================================================
+
+import { describe, it, expect } from 'vitest';
+
+import { applyBadgeGroupOptions, type BadgeCandidate } from '../../src/utils/badge-utils';
+import { makeHass } from '../fixtures/hass';
+
+function candidatesFixture(): BadgeCandidate[] {
+  return [
+    { entity: 'sensor.kitchen_power', color: 'orange' },
+    { entity: 'binary_sensor.kitchen_window', color: 'teal', showName: true },
+  ];
+}
+
+describe('applyBadgeGroupOptions', () => {
+  it('returns candidates unchanged without badge options', () => {
+    const hass = makeHass({});
+    const candidates = candidatesFixture();
+    expect(applyBadgeGroupOptions(candidates, undefined, hass)).toEqual(candidates);
+  });
+
+  it('removes deselected badges (badges.hidden still hides the badge)', () => {
+    const hass = makeHass({});
+    const result = applyBadgeGroupOptions(
+      candidatesFixture(),
+      { hidden: ['sensor.kitchen_power'] },
+      hass
+    );
+    expect(result.map(function toId(c) { return c.entity; })).toEqual([
+      'binary_sensor.kitchen_window',
+    ]);
+  });
+
+  it('appends additional badges only when they have a state, without duplicates', () => {
+    const hass = makeHass({
+      entities: [
+        { entity_id: 'sensor.kitchen_co2', attributes: { device_class: 'carbon_dioxide' } },
+      ],
+    });
+    const result = applyBadgeGroupOptions(
+      candidatesFixture(),
+      { additional: ['sensor.kitchen_co2', 'sensor.does_not_exist', 'sensor.kitchen_power'] },
+      hass
+    );
+    expect(result.map(function toId(c) { return c.entity; })).toEqual([
+      'sensor.kitchen_power',
+      'binary_sensor.kitchen_window',
+      'sensor.kitchen_co2',
+    ]);
+    // Color derives from the entity's device_class
+    expect(result.at(2)?.color).toBe('green');
+  });
+
+  it('does not mutate the input candidate list', () => {
+    const hass = makeHass({
+      entities: [{ entity_id: 'sensor.kitchen_co2', attributes: { device_class: 'carbon_dioxide' } }],
+    });
+    const candidates = candidatesFixture();
+    applyBadgeGroupOptions(candidates, { hidden: ['sensor.kitchen_power'], additional: ['sensor.kitchen_co2'] }, hass);
+    expect(candidates).toEqual(candidatesFixture());
+  });
+});

--- a/tests/views/CctvViewStrategy.test.ts
+++ b/tests/views/CctvViewStrategy.test.ts
@@ -107,6 +107,37 @@ describe('collectCameraBlocks', () => {
     expect(blocks[0].isReolink).toBe(true);
   });
 
+  it('keeps one block per lens for dual-lens cameras (#412)', () => {
+    const hass = makeHass({
+      areas: [{ area_id: 'einfahrt', name: 'Einfahrt' }],
+      devices: [
+        {
+          id: 'dev_omvi',
+          area_id: 'einfahrt',
+          manufacturer: 'Reolink',
+          model: 'Omvi 3i',
+          name: 'Einfahrt Kamera',
+        },
+      ],
+      entities: [
+        // One entity per lens with the SAME translation_key — both must
+        // survive; the main-stream variants are still deduped away.
+        { entity_id: 'camera.einfahrt_weit', device_id: 'dev_omvi', platform: 'reolink', translation_key: 'sub', attributes: { friendly_name: 'Einfahrt Weitwinkel' } },
+        { entity_id: 'camera.einfahrt_weit_klar', device_id: 'dev_omvi', platform: 'reolink', translation_key: 'main', attributes: { friendly_name: 'Einfahrt Weitwinkel Klar' } },
+        { entity_id: 'camera.einfahrt_zoom', device_id: 'dev_omvi', platform: 'reolink', translation_key: 'sub', attributes: { friendly_name: 'Einfahrt Zoom' } },
+        { entity_id: 'camera.einfahrt_zoom_klar', device_id: 'dev_omvi', platform: 'reolink', translation_key: 'main', attributes: { friendly_name: 'Einfahrt Zoom Klar' } },
+      ],
+    });
+    initRegistry(hass);
+
+    const blocks = collectCameraBlocks(hass, {});
+    expect(blocks.map((b) => b.cameraId).sort()).toEqual([
+      'camera.einfahrt_weit',
+      'camera.einfahrt_zoom',
+    ]);
+    expect(blocks.every((b) => b.deviceId === 'dev_omvi')).toBe(true);
+  });
+
   it('prefers the live view over the last-recording camera (Ring, #378)', () => {
     const hass = makeHass({
       areas: [{ area_id: 'eingang', name: 'Eingang' }],
@@ -353,6 +384,43 @@ describe('buildCctvSections', () => {
     expect(recordings?.tap_action?.navigation_path).toBe(
       `${ROOT_PATH}/${encodeURIComponent('playlist,media-source://reolink/CAM|entry_a|0')}`
     );
+  });
+
+  it('renders PTZ pad and recordings link only once per dual-lens device (#412)', async () => {
+    const spec = reolinkSpec();
+    // Second lens on the same device with the same translation_key
+    spec.entities?.push({
+      entity_id: 'camera.garten_zoom',
+      device_id: 'dev_garten',
+      platform: 'reolink',
+      translation_key: 'sub',
+      attributes: { friendly_name: 'Garten Kamera Zoom' },
+    });
+    const hass = makeHass(spec);
+    initRegistry(hass);
+    withCallWS(hass, function browse() {
+      return Promise.resolve({ children: [camChild('entry_a', '0', 'Garten Kamera')] });
+    });
+
+    const sections = await buildCctvSections(hass, {});
+    // Two camera sections for the same device
+    expect(sections).toHaveLength(2);
+
+    const ptzShortcuts = sections.map(function countPtz(section) {
+      return findCards(section.cards, 'shortcut').filter(function isPtz(card) {
+        return card.tap_action?.action === 'perform-action';
+      }).length;
+    });
+    const recordingLinks = sections.map(function countRecordings(section) {
+      return findCards(section.cards, 'shortcut').filter(function isNavigate(card) {
+        return card.tap_action?.action === 'navigate';
+      }).length;
+    });
+
+    // First block of the device carries PTZ + recordings, the second none
+    expect(ptzShortcuts.filter(function nonZero(n) { return n > 0; })).toHaveLength(1);
+    expect(recordingLinks).toEqual(expect.arrayContaining([1, 0]));
+    expect(recordingLinks.reduce(function sum(a, b) { return a + b; }, 0)).toBe(1);
   });
 
   it('hides cameras listed in hidden_cameras (shared with the security view)', async () => {


### PR DESCRIPTION
Drei Bugfixes aus der Issue-Triage vom 2026-08-13, alle live getestet:

- **Editor bietet keine config/diagnostic-Entitäten mehr an** — die Runtime filtert sie korrekt, der Editor zeigte sie trotzdem als Kandidaten (Gruppen + Badges). Closes #397
- **Badge-Abwahl blendet die Entität nicht mehr dashboard-weit aus** — die `badges`-Pseudo-Gruppe fließt nicht mehr ins globale Exclusion-Set; Badge-spezifische Ausblendung greift weiterhin (neue Tests). Teil von #396 (Rest folgt separat)
- **Dual-Lens-Kameras (z. B. Reolink Omvi 3i) rendern jetzt beide Objektive** — Dedup behält alle Entities mit dem besten translation_key; PTZ-Pad, Aufnahmen-Link und Glance-Overlay nur einmal pro Gerät; Ring-`live_view`-Pfad unverändert. Closes #412

Gates: tsc, ESLint, 204/204 Tests, Translation-Lint, Build — alle grün.
