### PR TITLE
chore: cut stable v1.4.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,9 +4,8 @@
     ".": {
       "release-type": "node",
       "include-component-in-tag": false,
-      "prerelease": true,
-      "versioning": "prerelease",
-      "prerelease-type": "beta",
+      "prerelease": false,
+      "versioning": "default",
       "extra-files": [
         "src/simon42-dashboard-strategy.ts"
       ]


### PR DESCRIPTION
Config-Flip für das Stable-Release: prerelease aus, versioning default. Der Squash-Merge trägt den Release-As-Footer, damit release-please das 1.4.0-Release-PR erzeugt (alle Commits sind bereits in beta.22 released).

Release-As: 1.4.0