### PR TITLE
fix(weather): hide sensors for zero or off

### DIFF
--- a/src/editor/panels/WeatherSensorsPanel.ts
+++ b/src/editor/panels/WeatherSensorsPanel.ts
@@ -3,7 +3,7 @@
 // ====================================================================
 // Per-row structured editor for the `weather_sensors` config array.
 // Each row binds to a WeatherSensorConfig and exposes inline inputs for
-// icon / unit / round. Adding a row uses the same entity-search picker
+// icon / unit / round / live visibility. Adding a row uses the same entity-search picker
 // pattern as favorites; removal is a single-click button.
 //
 // The picker filters to numeric-ish sensors by default but does not hard-
@@ -34,68 +34,121 @@ export function renderWeatherSensorsSection(host: StrategyEditorHost): TemplateR
   const filteredEntities = getFilteredEntities(host._hass, host._weatherSensorSearch);
 
   return html`
-      <div class="description" style="margin-left: 0; margin-bottom: 12px;">
-        ${localize('editor.weather_sensors_desc')}
-      </div>
+    <div class="description" style="margin-left: 0; margin-bottom: 12px;">
+      ${localize('editor.weather_sensors_desc')}
+    </div>
 
-      <div id="weather-sensors-list" style="margin-bottom: 12px;">
-        ${sensors.length === 0
-          ? html`<div class="empty-state">${localize('editor.no_weather_sensors')}</div>`
-          : sensors.map((sensor, index) => {
-              const name = entityMap.get(sensor.entity) || sensor.entity;
-              return html`
-                <div class="custom-item" data-sensor-index=${index}>
-                  <div class="custom-item-header">
-                    <strong>
-                      ${name}
-                      <span class="item-entity-id" style="font-weight: normal; margin-left: 8px;">
-                        ${sensor.entity}
-                      </span>
-                    </strong>
-                    <button class="btn-remove" @click=${() => removeWeatherSensor(host, index)}>&#x2715;</button>
+    <div id="weather-sensors-list" style="margin-bottom: 12px;">
+      ${sensors.length === 0
+        ? html`<div class="empty-state">${localize('editor.no_weather_sensors')}</div>`
+        : sensors.map((sensor, index) => {
+            const name = entityMap.get(sensor.entity) || sensor.entity;
+            return html`
+              <div class="custom-item" data-sensor-index=${index}>
+                <div class="custom-item-header">
+                  <strong>
+                    ${name}
+                    <span class="item-entity-id" style="font-weight: normal; margin-left: 8px;">
+                      ${sensor.entity}
+                    </span>
+                  </strong>
+                  <button class="btn-remove" @click=${() => removeWeatherSensor(host, index)}>&#x2715;</button>
+                </div>
+                <div class="custom-item-fields">
+                  <div class="custom-item-row">
+                    <input
+                      type="text"
+                      style="flex: 2;"
+                      placeholder=${localize('editor.weather_sensors_icon')}
+                      .value=${sensor.icon || ''}
+                      @change=${(e: Event) =>
+                        updateWeatherSensor(host, index, 'icon', (e.target as HTMLInputElement).value)}
+                    />
+                    <input
+                      type="text"
+                      style="flex: 1;"
+                      placeholder=${localize('editor.weather_sensors_unit')}
+                      .value=${sensor.unit || ''}
+                      @change=${(e: Event) =>
+                        updateWeatherSensor(host, index, 'unit', (e.target as HTMLInputElement).value)}
+                    />
+                    <input
+                      type="number"
+                      style="flex: 1;"
+                      min="0"
+                      max="6"
+                      step="1"
+                      placeholder=${localize('editor.weather_sensors_round')}
+                      .value=${sensor.round !== undefined ? String(sensor.round) : ''}
+                      @change=${(e: Event) =>
+                        updateWeatherSensor(host, index, 'round', (e.target as HTMLInputElement).value)}
+                    />
                   </div>
-                  <div class="custom-item-fields">
-                    <div class="custom-item-row">
-                      <input type="text" style="flex: 2;"
-                        placeholder=${localize('editor.weather_sensors_icon')}
-                        .value=${sensor.icon || ''}
-                        @change=${(e: Event) => updateWeatherSensor(host, index, 'icon', (e.target as HTMLInputElement).value)} />
-                      <input type="text" style="flex: 1;"
-                        placeholder=${localize('editor.weather_sensors_unit')}
-                        .value=${sensor.unit || ''}
-                        @change=${(e: Event) => updateWeatherSensor(host, index, 'unit', (e.target as HTMLInputElement).value)} />
-                      <input type="number" style="flex: 1;" min="0" max="6" step="1"
-                        placeholder=${localize('editor.weather_sensors_round')}
-                        .value=${sensor.round !== undefined ? String(sensor.round) : ''}
-                        @change=${(e: Event) => updateWeatherSensor(host, index, 'round', (e.target as HTMLInputElement).value)} />
-                    </div>
+                  <label class="form-row" style="margin-top: 8px;">
+                    <input
+                      type="checkbox"
+                      ?checked=${sensor.hide_when === 'zero_or_off'}
+                      @change=${(e: Event) =>
+                        updateWeatherSensor(
+                          host,
+                          index,
+                          'hide_when',
+                          (e.target as HTMLInputElement).checked ? 'zero_or_off' : ''
+                        )}
+                    />
+                    <span>${localize('editor.weather_sensors_hide_zero_off')}</span>
+                  </label>
+                  <div class="description" style="margin-left: 26px;">
+                    ${localize('editor.weather_sensors_hide_zero_off_desc')}
                   </div>
                 </div>
-              `;
-            })}
-      </div>
+              </div>
+            `;
+          })}
+    </div>
 
-      <div class="entity-search-picker">
-        <input type="text" class="entity-search-input"
-          placeholder=${localize('editor.weather_sensors_add')}
-          .value=${host._weatherSensorSearch}
-          @input=${(e: Event) => { host._weatherSensorSearch = (e.target as HTMLInputElement).value; host.requestUpdate(); }}
-          @blur=${() => { setTimeout(() => { host._weatherSensorSearch = ''; host.requestUpdate(); }, 200); }}
-        />
-        ${host._weatherSensorSearch.length >= 2 ? html`
-          <div class="entity-search-results">
-            ${filteredEntities.length > 0
-              ? filteredEntities.map((entity) => html`
-                <div class="entity-search-result" @mousedown=${(e: Event) => { e.preventDefault(); addWeatherSensor(host, entity.entity_id); host._weatherSensorSearch = ''; host.requestUpdate(); }}>
-                  <span class="entity-search-name">${entity.name}</span>
-                  <span class="entity-search-id">${entity.entity_id}</span>
-                </div>
-              `)
-              : html`<div class="entity-search-no-results">${localize('editor.no_results')}</div>`
-            }
-          </div>
-        ` : nothing}
-      </div>
+    <div class="entity-search-picker">
+      <input
+        type="text"
+        class="entity-search-input"
+        placeholder=${localize('editor.weather_sensors_add')}
+        .value=${host._weatherSensorSearch}
+        @input=${(e: Event) => {
+          host._weatherSensorSearch = (e.target as HTMLInputElement).value;
+          host.requestUpdate();
+        }}
+        @blur=${() => {
+          setTimeout(() => {
+            host._weatherSensorSearch = '';
+            host.requestUpdate();
+          }, 200);
+        }}
+      />
+      ${host._weatherSensorSearch.length >= 2
+        ? html`
+            <div class="entity-search-results">
+              ${filteredEntities.length > 0
+                ? filteredEntities.map(
+                    (entity) => html`
+                      <div
+                        class="entity-search-result"
+                        @mousedown=${(e: Event) => {
+                          e.preventDefault();
+                          addWeatherSensor(host, entity.entity_id);
+                          host._weatherSensorSearch = '';
+                          host.requestUpdate();
+                        }}
+                      >
+                        <span class="entity-search-name">${entity.name}</span>
+                        <span class="entity-search-id">${entity.entity_id}</span>
+                      </div>
+                    `
+                  )
+                : html`<div class="entity-search-no-results">${localize('editor.no_results')}</div>`}
+            </div>
+          `
+        : nothing}
+    </div>
   `;
 }
 
@@ -155,7 +208,7 @@ const ICON_RE = /^[a-z]+:[a-z0-9-]+$/;
  */
 function inferWeatherSensorDefaults(
   host: StrategyEditorHost,
-  entityId: string,
+  entityId: string
 ): { icon?: string; unit?: string; round?: number } {
   const state = host._hass ? stateFor(host._hass, entityId) : undefined;
   const attrs = (state?.attributes || {}) as Record<string, unknown>;
@@ -220,7 +273,7 @@ function updateWeatherSensor(
   host: StrategyEditorHost,
   index: number,
   field: keyof WeatherSensorConfig,
-  rawValue: string,
+  rawValue: string
 ): void {
   const current = host._config.weather_sensors || [];
   if (index < 0 || index >= current.length) return;
@@ -241,6 +294,9 @@ function updateWeatherSensor(
   } else if (field === 'unit') {
     if (trimmed === '') delete target.unit;
     else target.unit = trimmed;
+  } else if (field === 'hide_when') {
+    if (trimmed === 'zero_or_off') target.hide_when = 'zero_or_off';
+    else delete target.hide_when;
   } else {
     // remaining field is 'entity' — read-only via this method; ignore
     return;

--- a/src/sections/WeatherEnergySection.ts
+++ b/src/sections/WeatherEnergySection.ts
@@ -27,12 +27,18 @@ const ICON_RE = /^[a-z]+:[a-z0-9-]+$/;
 function escapeHtml(input: string): string {
   return input.replace(/[&<>"']/g, (c) => {
     switch (c) {
-      case '&': return '&amp;';
-      case '<': return '&lt;';
-      case '>': return '&gt;';
-      case '"': return '&quot;';
-      case "'": return '&#39;';
-      default: return c;
+      case '&':
+        return '&amp;';
+      case '<':
+        return '&lt;';
+      case '>':
+        return '&gt;';
+      case '"':
+        return '&quot;';
+      case "'":
+        return '&#39;';
+      default:
+        return c;
     }
   });
 }
@@ -62,24 +68,21 @@ function escapeHtml(input: string): string {
 function buildWeatherSensorRow(sensors: WeatherSensorConfig[]): LovelaceCardConfig | null {
   if (sensors.length === 0) return null;
 
-  const parts: string[] = [];
+  const parts: Array<{ entity: string; rendered: string; hideWhen: boolean }> = [];
+  const hasConditionalSensors = sensors.some((sensor) => sensor.hide_when === 'zero_or_off');
   for (const s of sensors) {
     if (typeof s.entity !== 'string' || !ENTITY_ID_RE.test(s.entity)) continue;
 
     const icon = typeof s.icon === 'string' && ICON_RE.test(s.icon) ? s.icon : 'mdi:gauge';
-    const round =
-      typeof s.round === 'number' && Number.isInteger(s.round) && s.round >= 0
-        ? s.round
-        : undefined;
+    const round = typeof s.round === 'number' && Number.isInteger(s.round) && s.round >= 0 ? s.round : undefined;
 
     const valueExpr =
-      round !== undefined
-        ? `{{ states("${s.entity}") | float(0) | round(${round}) }}`
-        : `{{ states("${s.entity}") }}`;
+      round !== undefined ? `{{ states("${s.entity}") | float(0) | round(${round}) }}` : `{{ states("${s.entity}") }}`;
 
     const unit = typeof s.unit === 'string' && s.unit.length > 0 ? ` ${escapeHtml(s.unit)}` : '';
 
-    parts.push(`<ha-icon icon="${icon}"></ha-icon> ${valueExpr}${unit}`);
+    const rendered = `<ha-icon icon="${icon}"></ha-icon> ${valueExpr}${unit}`;
+    parts.push({ entity: s.entity, rendered, hideWhen: s.hide_when === 'zero_or_off' });
   }
 
   if (parts.length === 0) return null;
@@ -87,7 +90,17 @@ function buildWeatherSensorRow(sensors: WeatherSensorConfig[]): LovelaceCardConf
   return {
     type: 'markdown',
     text_only: true,
-    content: parts.join(' &nbsp;&nbsp;&nbsp; '),
+    content: hasConditionalSensors
+      ? `{% set ns = namespace(first=true) %}${parts
+          .map((part) => {
+            const separator = '{% if not ns.first %} &nbsp;&nbsp;&nbsp; {% endif %}';
+            const visiblePart = `${separator}${part.rendered}{% set ns.first = false %}`;
+            return part.hideWhen
+              ? `{% set value = states("${part.entity}") %}{% if value | lower != "off" and (not is_number(value) or value | float(0) != 0) %}${visiblePart}{% endif %}`
+              : visiblePart;
+          })
+          .join('')}`
+      : parts.map((part) => part.rendered).join(' &nbsp;&nbsp;&nbsp; '),
   };
 }
 
@@ -172,10 +185,7 @@ ${localize('pollen.none')}{% endif %}`;
  * Returns null for `none` — caller emits no built-in card and the section
  * relies entirely on appended custom_cards.
  */
-function buildPresentationCard(
-  weatherEntity: string,
-  presentation: WeatherPresentation
-): LovelaceCardConfig | null {
+function buildPresentationCard(weatherEntity: string, presentation: WeatherPresentation): LovelaceCardConfig | null {
   switch (presentation) {
     case 'forecast_daily':
       return { type: 'weather-forecast', entity: weatherEntity, forecast_type: 'daily' };
@@ -218,8 +228,7 @@ export function createWeatherSection(
 ): LovelaceSectionConfig | null {
   if (!weatherEntity || !showWeather) return null;
 
-  const resolvedPresentation: WeatherPresentation =
-    presentation ?? (showForecastCard ? 'forecast_daily' : 'none');
+  const resolvedPresentation: WeatherPresentation = presentation ?? (showForecastCard ? 'forecast_daily' : 'none');
 
   const cards: LovelaceCardConfig[] = [];
   if (!hideHeading) {

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -210,6 +210,8 @@
     "weather_sensors_icon": "Icon",
     "weather_sensors_unit": "Einheit",
     "weather_sensors_round": "Dezimalstellen",
+    "weather_sensors_hide_zero_off": "Bei 0 oder „off“ ausblenden",
+    "weather_sensors_hide_zero_off_desc": "Blendet den Sensorwert live aus, wenn der Zustand numerisch 0 oder „off“ ist.",
     "weather_sensors_add": "+ Sensor hinzufügen",
     "no_weather_sensors": "Keine Sensoren konfiguriert. Suche unten, um einen hinzuzufügen.",
     "weather_entity": "Wetter-Entität:",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -210,6 +210,8 @@
     "weather_sensors_icon": "Icon",
     "weather_sensors_unit": "Unit",
     "weather_sensors_round": "Decimals",
+    "weather_sensors_hide_zero_off": "Hide when 0 or off",
+    "weather_sensors_hide_zero_off_desc": "Hides the sensor live when its state is numeric 0 or `off`.",
     "weather_sensors_add": "+ Add sensor",
     "no_weather_sensors": "No sensors configured. Use the picker below to add one.",
     "weather_entity": "Weather entity:",

--- a/src/translations/ru.json
+++ b/src/translations/ru.json
@@ -210,6 +210,8 @@
     "weather_sensors_icon": "Иконка",
     "weather_sensors_unit": "Ед. изм.",
     "weather_sensors_round": "Знаков после запятой",
+    "weather_sensors_hide_zero_off": "Скрывать при 0 или off",
+    "weather_sensors_hide_zero_off_desc": "Скрывает датчик в реальном времени, если его состояние равно числу 0 или `off`.",
     "weather_sensors_add": "+ Добавить датчик",
     "no_weather_sensors": "Датчики не настроены. Добавьте их с помощью списка ниже.",
     "weather_entity": "Погодная сущность:",

--- a/src/types/strategy.ts
+++ b/src/types/strategy.ts
@@ -379,12 +379,7 @@ export interface GroupOptions {
  * - `tile`                 — HA core `tile` card bound to the weather entity
  * - `none`                 — omit built-in card; section keeps heading + slot
  */
-export type WeatherPresentation =
-  | 'forecast_daily'
-  | 'forecast_hourly'
-  | 'forecast_twice_daily'
-  | 'tile'
-  | 'none';
+export type WeatherPresentation = 'forecast_daily' | 'forecast_hourly' | 'forecast_twice_daily' | 'tile' | 'none';
 
 // -- Weather Sensors --------------------------------------------------
 
@@ -402,6 +397,8 @@ export interface WeatherSensorConfig {
   unit?: string;
   /** Round the numeric value to N decimals. Omit to show raw state. */
   round?: number;
+  /** Hide the sensor when its live state is numeric zero or `off`. */
+  hide_when?: 'zero_or_off';
 }
 
 // -- Custom Views -----------------------------------------------------

--- a/tests/sections/WeatherEnergySection.test.ts
+++ b/tests/sections/WeatherEnergySection.test.ts
@@ -38,6 +38,39 @@ describe('createWeatherSection', () => {
     const forecast = section?.cards?.find((c) => c.type === 'weather-forecast');
     expect(forecast).toMatchObject({ forecast_type: 'daily' });
   });
+
+  it('renders configured weather sensor values with their formatting', () => {
+    const section = createWeatherSection('weather.home', true, true, [
+      { entity: 'sensor.temperature', icon: 'mdi:thermometer', unit: '°C', round: 1 },
+      { entity: 'sensor.condition', icon: 'mdi:weather-sunny' },
+    ]);
+    const sensorCard = section?.cards?.find((card) => card.type === 'markdown');
+
+    expect(sensorCard?.content).toContain('<ha-icon icon="mdi:thermometer"></ha-icon>');
+    expect(sensorCard?.content).toContain('{{ states("sensor.temperature") | float(0) | round(1) }} °C');
+    expect(sensorCard?.content).toContain('{{ states("sensor.condition") }}');
+  });
+
+  it('wraps zero-or-off weather sensors in a live visibility condition', () => {
+    const section = createWeatherSection('weather.home', true, true, [
+      { entity: 'sensor.temperature', hide_when: 'zero_or_off' },
+      { entity: 'sensor.humidity', round: 0 },
+    ]);
+    const sensorCard = section?.cards?.find((card) => card.type === 'markdown');
+    const content = String(sensorCard?.content);
+
+    expect(content).toContain('states("sensor.temperature")');
+    expect(content).toContain('value | lower != "off"');
+    expect(content).toContain('is_number(value)');
+    expect(content).toContain('states("sensor.humidity") | float(0) | round(0)');
+  });
+
+  it('keeps the default sensor rendering unchanged when no hide option is set', () => {
+    const section = createWeatherSection('weather.home', true, true, [{ entity: 'sensor.temperature' }]);
+    const sensorCard = section?.cards?.find((card) => card.type === 'markdown');
+
+    expect(sensorCard?.content).toBe('<ha-icon icon="mdi:gauge"></ha-icon> {{ states("sensor.temperature") }}');
+  });
 });
 
 describe('createEnergySection', () => {
@@ -50,10 +83,7 @@ describe('createEnergySection', () => {
     expect(section).not.toBeNull();
     expect(section).toMatchObject({
       type: 'grid',
-      cards: [
-        expect.objectContaining({ type: 'heading' }),
-        expect.objectContaining({ type: 'energy-distribution' }),
-      ],
+      cards: [expect.objectContaining({ type: 'heading' }), expect.objectContaining({ type: 'energy-distribution' })],
     });
   });
 
@@ -91,10 +121,20 @@ describe('buildPollenCard (DWD Pollenflug)', () => {
   it('builds a markdown template from discovered danger-index sensors', () => {
     const hass = makeHass({
       entities: [
-        pollenEntity('sensor.pollenflug_gefahrenindex_pollenflug_graeser_124', 'Pollenflug Gefahrenindex Pollenflug Gräser 124'),
-        pollenEntity('sensor.pollenflug_gefahrenindex_pollenflug_birke_124', 'Pollenflug Gefahrenindex Pollenflug Birke 124'),
+        pollenEntity(
+          'sensor.pollenflug_gefahrenindex_pollenflug_graeser_124',
+          'Pollenflug Gefahrenindex Pollenflug Gräser 124'
+        ),
+        pollenEntity(
+          'sensor.pollenflug_gefahrenindex_pollenflug_birke_124',
+          'Pollenflug Gefahrenindex Pollenflug Birke 124'
+        ),
         // Not a danger-index sensor (no state_today_desc) — must be ignored
-        { entity_id: 'sensor.pollenflug_region_124', platform: 'dwd_pollenflug', attributes: { friendly_name: 'Region' } },
+        {
+          entity_id: 'sensor.pollenflug_region_124',
+          platform: 'dwd_pollenflug',
+          attributes: { friendly_name: 'Region' },
+        },
       ],
     });
     const card = buildPollenCard(hass);
@@ -108,8 +148,14 @@ describe('buildPollenCard (DWD Pollenflug)', () => {
   it('dedupes allergens across multiple DWD regions (first wins)', () => {
     const hass = makeHass({
       entities: [
-        pollenEntity('sensor.pollenflug_gefahrenindex_pollenflug_birke_124', 'Pollenflug Gefahrenindex Pollenflug Birke 124'),
-        pollenEntity('sensor.pollenflug_gefahrenindex_pollenflug_birke_50', 'Pollenflug Gefahrenindex Pollenflug Birke 50'),
+        pollenEntity(
+          'sensor.pollenflug_gefahrenindex_pollenflug_birke_124',
+          'Pollenflug Gefahrenindex Pollenflug Birke 124'
+        ),
+        pollenEntity(
+          'sensor.pollenflug_gefahrenindex_pollenflug_birke_50',
+          'Pollenflug Gefahrenindex Pollenflug Birke 50'
+        ),
       ],
     });
     const card = buildPollenCard(hass);


### PR DESCRIPTION
## Ursache

Wetter-Sensorwerte konnten bisher nicht abhängig von ihrem Live-Zustand ausgeblendet werden.

## Änderung

- Ergänzt hide_when: zero_or_off für Wetter-Sensoren.
- Der Editor bietet die Option pro Sensor an.
- Der Markdown-Renderer blendet numerische Nullwerte und off live aus; die Standarddarstellung ohne Option bleibt unverändert.
- Trennzeichen werden bei ausgeblendeten Sensoren nicht stehen gelassen.

## Tests

- npm test — 244 Tests erfolgreich
- npm run lint — erfolgreich
- npm run format:check — erfolgreich
- npm run build — erfolgreich

Closes #394