### PR TITLE
fix(todos): keep custom cards in empty todo sections

### DIFF
--- a/src/sections/TodosSection.ts
+++ b/src/sections/TodosSection.ts
@@ -2,7 +2,8 @@
 // Todos Section Builder
 // ====================================================================
 // Renders one HA-native `todo-list` card per selected todo.* entity.
-// Auto-hides when no todo entities exist or none are selected.
+// Auto-hides when no todo entities exist or none are selected, unless custom
+// cards target the section and therefore need a section to attach to.
 // ====================================================================
 
 import type { HomeAssistant } from '../types/homeassistant';
@@ -20,18 +21,18 @@ import { localize } from '../utils/localize';
  * @param todoEntities optional explicit list (config). When empty/undefined,
  *                     all visible todo.* entities are included.
  * @param hideHeading suppress the section heading
+ * @param hasAssignedCards keep a heading-only section for custom cards
  */
 export function createTodosSection(
   hass: HomeAssistant,
   enabled: boolean,
   todoEntities: string[] | undefined,
-  hideHeading: boolean = false
+  hideHeading: boolean = false,
+  hasAssignedCards: boolean = false
 ): LovelaceSectionConfig | null {
   if (!enabled) return null;
 
-  const visible = Registry.getVisibleEntityIdsForDomain('todo').filter(
-    (id) => hass.states[id] !== undefined
-  );
+  const visible = Registry.getVisibleEntityIdsForDomain('todo').filter((id) => hass.states[id] !== undefined);
 
   let selected: string[];
   if (Array.isArray(todoEntities) && todoEntities.length > 0) {
@@ -40,7 +41,7 @@ export function createTodosSection(
     selected = visible;
   }
 
-  if (selected.length === 0) return null;
+  if (selected.length === 0 && !hasAssignedCards) return null;
 
   const cards: LovelaceCardConfig[] = [];
   if (!hideHeading) {
@@ -63,3 +64,4 @@ export function createTodosSection(
 
   return { type: 'grid', cards };
 }
+

--- a/src/sections/TodosSection.ts
+++ b/src/sections/TodosSection.ts
@@ -32,7 +32,9 @@ export function createTodosSection(
 ): LovelaceSectionConfig | null {
   if (!enabled) return null;
 
-  const visible = Registry.getVisibleEntityIdsForDomain('todo').filter((id) => hass.states[id] !== undefined);
+  const visible = Registry.getVisibleEntityIdsForDomain('todo').filter(
+    (id) => Reflect.get(hass.states as Record<string, unknown>, id) !== undefined
+  );
 
   let selected: string[];
   if (Array.isArray(todoEntities) && todoEntities.length > 0) {

--- a/src/views/OverviewViewStrategy.ts
+++ b/src/views/OverviewViewStrategy.ts
@@ -188,7 +188,9 @@ class Simon42ViewOverviewStrategy extends HTMLElement {
     // exists in this hass instance, otherwise fall back to auto-discovery.
     const configuredWeather = dashboardConfig.weather_entity;
     const weatherEntity =
-      configuredWeather && hass.states[configuredWeather] ? configuredWeather : findWeatherEntity(hass);
+      configuredWeather && Reflect.get(hass.states as Record<string, unknown>, configuredWeather)
+        ? configuredWeather
+        : findWeatherEntity(hass);
     const someSensorId = findDummySensor(hass);
 
     // Person badges (default-on; suppress via show_person_badges=false to swap in

--- a/src/views/OverviewViewStrategy.ts
+++ b/src/views/OverviewViewStrategy.ts
@@ -10,7 +10,12 @@ import type { HomeAssistant } from '../types/homeassistant';
 import type { Simon42StrategyConfig, SectionKey, SectionOrderKey, CustomCard, HeadingKey } from '../types/strategy';
 import { DEFAULT_SECTIONS_ORDER } from '../types/strategy';
 import { validateCustomSections, buildCustomSection } from '../sections/CustomSections';
-import type { LovelaceViewConfig, LovelaceSectionConfig, LovelaceBadgeConfig, LovelaceCardConfig } from '../types/lovelace';
+import type {
+  LovelaceViewConfig,
+  LovelaceSectionConfig,
+  LovelaceBadgeConfig,
+  LovelaceCardConfig,
+} from '../types/lovelace';
 import type { AreaRegistryEntry } from '../types/registries';
 import { Registry } from '../Registry';
 import { collectPersons, findWeatherEntity, findDummySensor } from '../utils/entity-filter';
@@ -142,8 +147,16 @@ const SECTION_BUILDER_IMPL: Record<SectionKey, SectionBuilder> = {
   plants: ({ hass, config }) => createPlantsSection(hass, config.show_plants_section === true),
   agenda: ({ hass, config }) =>
     createAgendaSection(hass, config.show_agenda_section === true, config.agenda_calendar_entities),
-  todos: ({ hass, config }) =>
-    createTodosSection(hass, config.show_todos_section === true, config.todos_entities),
+  todos: ({ hass, config, customCardsBySection }) =>
+    createTodosSection(
+      hass,
+      config.show_todos_section === true,
+      config.todos_entities,
+      false,
+      (customCardsBySection.get('todos') || []).some(
+        (card) => card.parsed_config !== undefined && card.parsed_config !== null
+      )
+    ),
   persons: ({ hass, config }) => createPersonsSection(hass, config.show_persons_section === true),
   vacuums: ({ hass, config }) => createVacuumsSection(hass, config.show_vacuums_section === true),
   maintenance: ({ hass, config }) => createMaintenanceSection(hass, config.show_maintenance_section === true),
@@ -163,7 +176,11 @@ class Simon42ViewOverviewStrategy extends HTMLElement {
     Registry.initialize(hass, dashboardConfig);
 
     // Visible areas (filtered + sorted by config)
-    const visibleAreas = getVisibleAreas(Registry.areas, dashboardConfig.areas_display, dashboardConfig.use_default_area_sort);
+    const visibleAreas = getVisibleAreas(
+      Registry.areas,
+      dashboardConfig.areas_display,
+      dashboardConfig.use_default_area_sort
+    );
 
     // Collect data for overview
     const persons = collectPersons(hass, dashboardConfig);
@@ -171,9 +188,7 @@ class Simon42ViewOverviewStrategy extends HTMLElement {
     // exists in this hass instance, otherwise fall back to auto-discovery.
     const configuredWeather = dashboardConfig.weather_entity;
     const weatherEntity =
-      configuredWeather && hass.states[configuredWeather]
-        ? configuredWeather
-        : findWeatherEntity(hass);
+      configuredWeather && hass.states[configuredWeather] ? configuredWeather : findWeatherEntity(hass);
     const someSensorId = findDummySensor(hass);
 
     // Person badges (default-on; suppress via show_person_badges=false to swap in
@@ -222,7 +237,9 @@ class Simon42ViewOverviewStrategy extends HTMLElement {
     for (const key of sectionsOrder) {
       const rule = Reflect.get(sectionVisibility, key) as { entity?: string; state?: string } | undefined;
       if (rule?.entity) {
-        const entState = Reflect.get(hass.states as Record<string, unknown>, rule.entity) as { state?: string } | undefined;
+        const entState = Reflect.get(hass.states as Record<string, unknown>, rule.entity) as
+          | { state?: string }
+          | undefined;
         if (!entState || entState.state !== rule.state) continue;
       }
       // Built-in sections come from the builder map; unknown keys are
@@ -370,16 +387,21 @@ class Simon42ViewOverviewStrategy extends HTMLElement {
       }
     }
 
-    return createOverviewView(overviewSections, [
-      ...personBadges,
-      ...powerBadges,
-      ...alertBadges,
-      ...nowPlayingBadges,
-      ...sunBadges,
-      ...updatesBadges,
-      ...customBadges,
-    ], dashboardConfig);
+    return createOverviewView(
+      overviewSections,
+      [
+        ...personBadges,
+        ...powerBadges,
+        ...alertBadges,
+        ...nowPlayingBadges,
+        ...sunBadges,
+        ...updatesBadges,
+        ...customBadges,
+      ],
+      dashboardConfig
+    );
   }
 }
 
 customElements.define('ll-strategy-simon42-view-overview', Simon42ViewOverviewStrategy);
+

--- a/tests/sections/TodosSection.test.ts
+++ b/tests/sections/TodosSection.test.ts
@@ -1,0 +1,62 @@
+// ============================================================================
+// Tests — Todos section auto-hide and custom-card attachment
+// ============================================================================
+
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { Registry } from '../../src/Registry';
+import { createTodosSection } from '../../src/sections/TodosSection';
+import { makeHass } from '../fixtures/hass';
+
+beforeEach(() => {
+  Registry.resetForTesting();
+});
+
+describe('createTodosSection', () => {
+  it('keeps the existing auto-hide behavior when no native todo entity exists', () => {
+    const hass = makeHass();
+    Registry.initialize(hass, {});
+
+    expect(createTodosSection(hass, true, undefined)).toBeNull();
+  });
+
+  it('keeps an otherwise empty enabled section for assigned custom cards', () => {
+    const hass = makeHass();
+    Registry.initialize(hass, {});
+
+    expect(createTodosSection(hass, true, undefined, false, true)).toEqual({
+      type: 'grid',
+      cards: [
+        {
+          type: 'heading',
+          heading_style: 'title',
+          heading: 'To-do',
+          icon: 'mdi:format-list-checks',
+        },
+      ],
+    });
+  });
+
+  it('renders native todo-list cards when todo entities are available', () => {
+    const hass = makeHass({ entities: [{ entity_id: 'todo.shopping' }] });
+    Registry.initialize(hass, {});
+
+    expect(createTodosSection(hass, true, undefined)?.cards).toEqual([
+      {
+        type: 'heading',
+        heading_style: 'title',
+        heading: 'To-do',
+        icon: 'mdi:format-list-checks',
+      },
+      { type: 'todo-list', entity: 'todo.shopping' },
+    ]);
+  });
+
+  it('remains disabled even when custom cards target todos', () => {
+    const hass = makeHass();
+    Registry.initialize(hass, {});
+
+    expect(createTodosSection(hass, false, undefined, false, true)).toBeNull();
+  });
+});
+


### PR DESCRIPTION
## Ursache

Die Todos-Sektion wurde automatisch entfernt, sobald keine nativen todo.*-Entitäten verfügbar waren. Eigene Karten mit target_section: todos verloren dadurch ihren Zielbereich.

## Änderung

- Eine aktivierte Todos-Sektion bleibt bei zugewiesenen eigenen Karten als leerer Anker erhalten.
- Native todo-list-Karten werden weiterhin wie bisher erzeugt.
- Ohne aktivierte Todos-Sektion oder ohne zugewiesene Karten bleibt das bisherige Auto-Hide-Verhalten erhalten.

## Tests

- npm test — 245 Tests erfolgreich
- npm run lint — erfolgreich
- npm run format:check — erfolgreich
- npm run build — erfolgreich

Closes #429