### PR TITLE
fix(areas): respect hidden areas in utility views

### DIFF
--- a/src/Registry.ts
+++ b/src/Registry.ts
@@ -399,9 +399,36 @@ class Registry {
   /**
    * Get visible entity IDs for a domain. O(1).
    * Pre-filtered: no hidden, no_dboard, config/diagnostic, config-hidden.
+   *
+   * When requested, also excludes entities assigned to an area listed in
+   * areas_display.hidden. This is opt-in because security views intentionally
+   * keep showing hidden-area entities unless their dedicated configuration is
+   * enabled.
    */
-  static getVisibleEntityIdsForDomain(domain: string): string[] {
-    return Registry._visibleEntitiesByDomain.get(domain) || [];
+  static getVisibleEntityIdsForDomain(domain: string, excludeHiddenAreas = false): string[] {
+    const ids = Registry._visibleEntitiesByDomain.get(domain) || [];
+    if (!excludeHiddenAreas) return ids;
+
+    return ids.filter((entityId) => !Registry.isEntityInHiddenArea(entityId));
+  }
+
+  /** Resolve an entity's explicit or device-inherited area. */
+  static getAreaIdForEntity(entityId: string): string | null {
+    const entity = Registry._entityById.get(entityId);
+    if (!entity) return null;
+    if (entity.area_id) return entity.area_id;
+    return entity.device_id ? (Registry._deviceById.get(entity.device_id)?.area_id ?? null) : null;
+  }
+
+  /** Whether an area is hidden by the dashboard's areas_display config. */
+  static isAreaHidden(areaId: string): boolean {
+    return Registry._config.areas_display?.hidden?.includes(areaId) === true;
+  }
+
+  /** Whether an entity belongs to an area hidden from utility views. */
+  static isEntityInHiddenArea(entityId: string): boolean {
+    const areaId = Registry.getAreaIdForEntity(entityId);
+    return areaId ? Registry.isAreaHidden(areaId) : false;
   }
 
   /**
@@ -544,3 +571,4 @@ class Registry {
 }
 
 export { Registry };
+

--- a/src/cards/CoversGroupCard.ts
+++ b/src/cards/CoversGroupCard.ts
@@ -160,7 +160,7 @@ class Simon42CoversGroupCard extends LitElement {
   }
 
   private _getFilteredCoverEntities(hass: HomeAssistant): string[] {
-    return Registry.getVisibleEntityIdsForDomain('cover').filter((id) => {
+    return Registry.getVisibleEntityIdsForDomain('cover', true).filter((id) => {
       const state = hass.states[id];
       if (!state) return false;
       const deviceClass = (state.attributes as any)?.device_class as string | undefined;
@@ -284,8 +284,15 @@ class Simon42CoversGroupCard extends LitElement {
    */
   private _groupByAreas(covers: string[]): CoversAreaGroup[] {
     if (!this.hass) return [];
-    const dashboardConfig = (this._config.config || {}) as { areas_display?: AreasDisplay; use_default_area_sort?: boolean };
-    const visibleAreas = getVisibleAreasFromHass(this.hass, dashboardConfig.areas_display, dashboardConfig.use_default_area_sort);
+    const dashboardConfig = (this._config.config || {}) as {
+      areas_display?: AreasDisplay;
+      use_default_area_sort?: boolean;
+    };
+    const visibleAreas = getVisibleAreasFromHass(
+      this.hass,
+      dashboardConfig.areas_display,
+      dashboardConfig.use_default_area_sort
+    );
 
     const byArea = new Map<string, string[]>();
     const noArea: string[] = [];
@@ -341,7 +348,7 @@ class Simon42CoversGroupCard extends LitElement {
 
   private _buildHeadingConfig(
     covers: string[],
-    opts: { label?: string; icon?: string; level?: 'main' | 'floor' | 'area'; areaId?: string | null } = {},
+    opts: { label?: string; icon?: string; level?: 'main' | 'floor' | 'area'; areaId?: string | null } = {}
   ): Record<string, unknown> {
     const level = opts.level ?? 'main';
 
@@ -400,12 +407,14 @@ class Simon42CoversGroupCard extends LitElement {
     }
 
     const isOpen = groupType === 'open';
-    const headingLabel = floorLabel || (isOpen
-      ? (this._config.heading_open || localize('covers.open'))
-      : (this._config.heading_closed || localize('covers.closed')));
+    const headingLabel =
+      floorLabel ||
+      (isOpen
+        ? this._config.heading_open || localize('covers.open')
+        : this._config.heading_closed || localize('covers.closed'));
     const defaultIcon = isOpen ? 'mdi:blinds-horizontal' : 'mdi:blinds';
-    const headingIcon = floorIcon
-      || (isOpen ? (this._config.icon_open || defaultIcon) : (this._config.icon_closed || defaultIcon));
+    const headingIcon =
+      floorIcon || (isOpen ? this._config.icon_open || defaultIcon : this._config.icon_closed || defaultIcon);
     return {
       type: 'heading',
       heading: `${headingLabel} (${covers.length})`,
@@ -549,7 +558,7 @@ class Simon42CoversGroupCard extends LitElement {
     slotId: string,
     cardMap: Map<string, LovelaceCardElement>,
     key: string,
-    headingConfig: Record<string, unknown>,
+    headingConfig: Record<string, unknown>
   ): void {
     const hass = this.hass;
     if (!hass) return;
@@ -644,7 +653,7 @@ class Simon42CoversGroupCard extends LitElement {
           `floor-heading-${floorKey}`,
           this._floorHeadingCards,
           floorKey,
-          this._buildHeadingConfig(group.covers, { label: group.floorName, icon: group.floorIcon, level: 'floor' }),
+          this._buildHeadingConfig(group.covers, { label: group.floorName, icon: group.floorIcon, level: 'floor' })
         );
 
         if (groupByAreas) {
@@ -658,7 +667,7 @@ class Simon42CoversGroupCard extends LitElement {
               this._getAreaSlotId('area-heading', floorKey, areaKey),
               this._areaHeadingCards,
               compositeKey,
-              this._buildHeadingConfig(area.covers, { label: area.areaName, level: 'area', areaId: area.areaId }),
+              this._buildHeadingConfig(area.covers, { label: area.areaName, level: 'area', areaId: area.areaId })
             );
             this._reconcileGrid(this._getAreaSlotId('area-grid', floorKey, areaKey), area.covers);
           }
@@ -684,7 +693,7 @@ class Simon42CoversGroupCard extends LitElement {
           this._getAreaSlotId('area-heading', null, areaKey),
           this._areaHeadingCards,
           areaKey,
-          this._buildHeadingConfig(area.covers, { label: area.areaName, level: 'area', areaId: area.areaId }),
+          this._buildHeadingConfig(area.covers, { label: area.areaName, level: 'area', areaId: area.areaId })
         );
         this._reconcileGrid(this._getAreaSlotId('area-grid', null, areaKey), area.covers);
       }
@@ -705,3 +714,4 @@ class Simon42CoversGroupCard extends LitElement {
 }
 
 customElements.define('simon42-covers-group-card', Simon42CoversGroupCard);
+

--- a/src/cards/LightsGroupCard.ts
+++ b/src/cards/LightsGroupCard.ts
@@ -200,9 +200,11 @@ class Simon42LightsGroupCard extends LitElement {
 
   private _getSourceLightEntities(): string[] {
     if (Array.isArray(this._config.entities) && this._config.entities.length > 0) {
-      return this._config.entities.filter((id) => id.startsWith('light.') && this._getState(id) !== undefined);
+      return this._config.entities.filter(
+        (id) => id.startsWith('light.') && !Registry.isEntityInHiddenArea(id) && this._getState(id) !== undefined
+      );
     }
-    return Registry.getVisibleEntityIdsForDomain('light').filter((id) => this._getState(id) !== undefined);
+    return Registry.getVisibleEntityIdsForDomain('light', true).filter((id) => this._getState(id) !== undefined);
   }
 
   private _getRelevantLights(lightIds?: Iterable<string>): string[] {
@@ -364,10 +366,7 @@ class Simon42LightsGroupCard extends LitElement {
     // Object.keys() insertion order — no separate sort_order field needed.
     const floors = this.hass.floors;
     const floorOrder = Object.keys(floors);
-    const sortedKeys = [
-      ...floorOrder.filter((id) => floorMap.has(id)),
-      ...(floorMap.has(null) ? [null] : []),
-    ];
+    const sortedKeys = [...floorOrder.filter((id) => floorMap.has(id)), ...(floorMap.has(null) ? [null] : [])];
 
     return sortedKeys.map((floorId) => {
       const floor = floorId ? floors[floorId] : null;
@@ -389,8 +388,15 @@ class Simon42LightsGroupCard extends LitElement {
    */
   private _groupByAreas(lights: string[]): LightsAreaGroup[] {
     if (!this.hass) return [];
-    const dashboardConfig = (this._config.config || {}) as { areas_display?: AreasDisplay; use_default_area_sort?: boolean };
-    const visibleAreas = getVisibleAreasFromHass(this.hass, dashboardConfig.areas_display, dashboardConfig.use_default_area_sort);
+    const dashboardConfig = (this._config.config || {}) as {
+      areas_display?: AreasDisplay;
+      use_default_area_sort?: boolean;
+    };
+    const visibleAreas = getVisibleAreasFromHass(
+      this.hass,
+      dashboardConfig.areas_display,
+      dashboardConfig.use_default_area_sort
+    );
 
     const byArea = new Map<string, string[]>();
     const noArea: string[] = [];
@@ -432,7 +438,7 @@ class Simon42LightsGroupCard extends LitElement {
 
   private _buildHeadingConfig(
     lights: string[],
-    opts: { label?: string; icon?: string; level?: 'main' | 'floor' | 'area'; areaId?: string | null } = {},
+    opts: { label?: string; icon?: string; level?: 'main' | 'floor' | 'area'; areaId?: string | null } = {}
   ): Record<string, unknown> {
     const level = opts.level ?? 'main';
 
@@ -458,7 +464,7 @@ class Simon42LightsGroupCard extends LitElement {
     const label = opts.label;
     const heading = label
       ? `${label} (${lights.length})`
-      : `${isAll ? (this._config.heading_label || localize('room.lighting')) : (isOn ? localize('lights.on') : localize('lights.off'))} (${lights.length})`;
+      : `${isAll ? this._config.heading_label || localize('room.lighting') : isOn ? localize('lights.on') : localize('lights.off')} (${lights.length})`;
 
     const badges =
       lights.length === 0
@@ -473,7 +479,9 @@ class Simon42LightsGroupCard extends LitElement {
                 perform_action: 'light.turn_on',
                 target: { entity_id: lights },
               },
-              visibility: [{ condition: 'or', conditions: lights.map((entity) => ({ condition: 'state', entity, state: 'off' })) }],
+              visibility: [
+                { condition: 'or', conditions: lights.map((entity) => ({ condition: 'state', entity, state: 'off' })) },
+              ],
             },
             {
               type: 'button',
@@ -484,7 +492,9 @@ class Simon42LightsGroupCard extends LitElement {
                 perform_action: 'light.turn_off',
                 target: { entity_id: lights },
               },
-              visibility: [{ condition: 'or', conditions: lights.map((entity) => ({ condition: 'state', entity, state: 'on' })) }],
+              visibility: [
+                { condition: 'or', conditions: lights.map((entity) => ({ condition: 'state', entity, state: 'on' })) },
+              ],
             },
           ];
 
@@ -526,7 +536,7 @@ class Simon42LightsGroupCard extends LitElement {
   }
 
   private _isExpanded(entityId: string): boolean {
-    return this._groupExpansion.get(entityId) ?? (this._config.default_expanded === true);
+    return this._groupExpansion.get(entityId) ?? this._config.default_expanded === true;
   }
 
   private _getOrCreateGroupContainer(entityId: string): HTMLElement {
@@ -577,7 +587,11 @@ class Simon42LightsGroupCard extends LitElement {
     return this._getOrCreateTileCard(entityId) as unknown as HTMLElement;
   }
 
-  private _placeHierarchyNode(parentElement: HTMLElement, childElement: HTMLElement, referenceNode: ChildNode | null): void {
+  private _placeHierarchyNode(
+    parentElement: HTMLElement,
+    childElement: HTMLElement,
+    referenceNode: ChildNode | null
+  ): void {
     if (childElement !== referenceNode) {
       parentElement.insertBefore(childElement, referenceNode);
     }
@@ -706,7 +720,7 @@ class Simon42LightsGroupCard extends LitElement {
     slotId: string,
     cardMap: Map<string, LovelaceCardElement>,
     key: string,
-    headingConfig: Record<string, unknown>,
+    headingConfig: Record<string, unknown>
   ): void {
     const hass = this.hass;
     if (!hass) return;
@@ -793,7 +807,7 @@ class Simon42LightsGroupCard extends LitElement {
           `floor-heading-${floorKey}`,
           this._floorHeadingCards,
           floorKey,
-          this._buildHeadingConfig(group.lights, { label: group.floorName, icon: group.floorIcon, level: 'floor' }),
+          this._buildHeadingConfig(group.lights, { label: group.floorName, icon: group.floorIcon, level: 'floor' })
         );
 
         if (groupByAreas) {
@@ -807,7 +821,7 @@ class Simon42LightsGroupCard extends LitElement {
               this._getAreaSlotId('area-heading', floorKey, areaKey),
               this._areaHeadingCards,
               compositeKey,
-              this._buildHeadingConfig(area.lights, { label: area.areaName, level: 'area', areaId: area.areaId }),
+              this._buildHeadingConfig(area.lights, { label: area.areaName, level: 'area', areaId: area.areaId })
             );
             this._reconcileLightsGrid(this._getAreaSlotId('area-grid', floorKey, areaKey), area.lights);
           }
@@ -833,7 +847,7 @@ class Simon42LightsGroupCard extends LitElement {
           this._getAreaSlotId('area-heading', null, areaKey),
           this._areaHeadingCards,
           areaKey,
-          this._buildHeadingConfig(area.lights, { label: area.areaName, level: 'area', areaId: area.areaId }),
+          this._buildHeadingConfig(area.lights, { label: area.areaName, level: 'area', areaId: area.areaId })
         );
         this._reconcileLightsGrid(this._getAreaSlotId('area-grid', null, areaKey), area.lights);
       }
@@ -854,3 +868,4 @@ class Simon42LightsGroupCard extends LitElement {
 }
 
 customElements.define('simon42-lights-group-card', Simon42LightsGroupCard);
+

--- a/src/cards/SummaryCard.ts
+++ b/src/cards/SummaryCard.ts
@@ -31,7 +31,16 @@ interface DisplayConfig {
 const COVER_DEVICE_CLASSES = new Set(['awning', 'blind', 'curtain', 'shade', 'shutter', 'window']);
 
 const SECURITY_COVER_CLASSES = new Set(['door', 'garage', 'gate', 'window']);
-const SECURITY_BINARY_SENSOR_CLASSES = new Set(['door', 'window', 'garage_door', 'opening', 'smoke', 'gas', 'heat', 'moisture']);
+const SECURITY_BINARY_SENSOR_CLASSES = new Set([
+  'door',
+  'window',
+  'garage_door',
+  'opening',
+  'smoke',
+  'gas',
+  'heat',
+  'moisture',
+]);
 
 const COLOR_MAP: Record<string, string> = {
   orange: 'var(--orange-color, #ff9800)',
@@ -129,13 +138,13 @@ class Simon42SummaryCard extends LitElement {
 
     switch (this._config.summary_type) {
       case 'lights':
-        result = Registry.getVisibleEntityIdsForDomain('light').filter(
+        result = Registry.getVisibleEntityIdsForDomain('light', true).filter(
           (id) => hass.states[id] && this._isEntityRelevant(id, hass.states[id])
         );
         break;
 
       case 'covers':
-        result = Registry.getVisibleEntityIdsForDomain('cover').filter((id) => {
+        result = Registry.getVisibleEntityIdsForDomain('cover', true).filter((id) => {
           const state = hass.states[id];
           if (!state) return false;
           if (!this._isEntityRelevant(id, state)) return false;
@@ -301,13 +310,17 @@ class Simon42SummaryCard extends LitElement {
     const configs: Record<SummaryType, DisplayConfig> = {
       lights: {
         icon: 'mdi:lamps',
-        name: hasItems ? `${count} ${count === 1 ? localize('summary.lights_on_one') : localize('summary.lights_on_many')}` : localize('summary.lights_off'),
+        name: hasItems
+          ? `${count} ${count === 1 ? localize('summary.lights_on_one') : localize('summary.lights_on_many')}`
+          : localize('summary.lights_off'),
         color: hasItems ? 'orange' : 'grey',
         path: 'lights',
       },
       covers: {
         icon: 'mdi:blinds-horizontal',
-        name: hasItems ? `${count} ${count === 1 ? localize('summary.covers_open_one') : localize('summary.covers_open_many')}` : localize('summary.covers_closed'),
+        name: hasItems
+          ? `${count} ${count === 1 ? localize('summary.covers_open_one') : localize('summary.covers_open_many')}`
+          : localize('summary.covers_closed'),
         color: hasItems ? 'purple' : 'grey',
         path: 'covers',
       },
@@ -319,19 +332,25 @@ class Simon42SummaryCard extends LitElement {
       },
       batteries: {
         icon: hasItems ? 'mdi:battery-alert' : 'mdi:battery-charging',
-        name: hasItems ? `${count} ${count === 1 ? localize('summary.batteries_critical_one') : localize('summary.batteries_critical_many')}` : localize('summary.batteries_ok'),
+        name: hasItems
+          ? `${count} ${count === 1 ? localize('summary.batteries_critical_one') : localize('summary.batteries_critical_many')}`
+          : localize('summary.batteries_ok'),
         color: hasItems ? 'red' : 'grey',
         path: 'batteries',
       },
       climate: {
         icon: 'mdi:thermostat',
-        name: hasItems ? `${count} ${count === 1 ? localize('summary.climate_active_one') : localize('summary.climate_active_many')}` : localize('summary.climate_off'),
+        name: hasItems
+          ? `${count} ${count === 1 ? localize('summary.climate_active_one') : localize('summary.climate_active_many')}`
+          : localize('summary.climate_off'),
         color: hasItems ? 'orange' : 'grey',
         path: 'climate',
       },
       maintenance: {
         icon: 'mdi:wrench',
-        name: hasItems ? `${count} ${count === 1 ? localize('summary.maintenance_pending_one') : localize('summary.maintenance_pending_many')}` : localize('summary.maintenance_ok'),
+        name: hasItems
+          ? `${count} ${count === 1 ? localize('summary.maintenance_pending_one') : localize('summary.maintenance_pending_many')}`
+          : localize('summary.maintenance_ok'),
         color: hasItems ? 'orange' : 'grey',
         path: 'maintenance',
       },
@@ -361,7 +380,6 @@ class Simon42SummaryCard extends LitElement {
   }
 
   protected render() {
-
     const display = this._getDisplayConfig();
     const colorCss = COLOR_MAP[display.color] || COLOR_MAP.grey;
 
@@ -383,3 +401,4 @@ customElements.define('simon42-summary-card', Simon42SummaryCard);
 // Deliberately NOT registered in window.customCards: the card only works
 // inside the strategy (Registry + localize lifecycle, see #147). Listing it
 // in the card picker would invite standalone use that breaks.
+

--- a/tests/Registry.test.ts
+++ b/tests/Registry.test.ts
@@ -49,9 +49,9 @@ describe('Registry.initialize', () => {
     });
     Registry.initialize(updated, {});
 
-    const ids = Registry.getVisibleEntitiesForArea('kitchen').map(
-      function toId(e) { return e.entity_id; }
-    );
+    const ids = Registry.getVisibleEntitiesForArea('kitchen').map(function toId(e) {
+      return e.entity_id;
+    });
     expect(ids).toEqual(['light.kitchen', 'light.kitchen_2']);
   });
 
@@ -61,14 +61,22 @@ describe('Registry.initialize', () => {
       entities: [{ entity_id: 'light.kitchen', area_id: 'kitchen' }],
     });
     Registry.initialize(hass, {});
-    expect(Registry.areas.map(function toName(a) { return a.name; })).toEqual(['Kitchen']);
+    expect(
+      Registry.areas.map(function toName(a) {
+        return a.name;
+      })
+    ).toEqual(['Kitchen']);
 
     const updated = makeHass({
       areas: [{ area_id: 'kitchen', name: 'Küche' }],
       entities: [{ entity_id: 'light.kitchen', area_id: 'kitchen' }],
     });
     Registry.initialize(updated, {});
-    expect(Registry.areas.map(function toName(a) { return a.name; })).toEqual(['Küche']);
+    expect(
+      Registry.areas.map(function toName(a) {
+        return a.name;
+      })
+    ).toEqual(['Küche']);
   });
 
   it('picks up the current config on a registry-triggered rebuild', () => {
@@ -98,7 +106,11 @@ describe('badges pseudo-group exclusion (#396)', () => {
     const hass = makeHass({
       areas: [{ area_id: 'kitchen', name: 'Kitchen' }],
       entities: [
-        { entity_id: 'sensor.kitchen_power', area_id: 'kitchen', attributes: { device_class: 'power', unit_of_measurement: 'W' } },
+        {
+          entity_id: 'sensor.kitchen_power',
+          area_id: 'kitchen',
+          attributes: { device_class: 'power', unit_of_measurement: 'W' },
+        },
       ],
     });
     const config = {
@@ -112,7 +124,9 @@ describe('badges pseudo-group exclusion (#396)', () => {
     expect(Registry.isHiddenByConfig('sensor.kitchen_power')).toBe(false);
     expect(Registry.isEntityExcluded('sensor.kitchen_power')).toBe(false);
     expect(
-      Registry.getVisibleEntitiesForArea('kitchen').map(function toId(e) { return e.entity_id; })
+      Registry.getVisibleEntitiesForArea('kitchen').map(function toId(e) {
+        return e.entity_id;
+      })
     ).toEqual(['sensor.kitchen_power']);
   });
 
@@ -132,3 +146,46 @@ describe('badges pseudo-group exclusion (#396)', () => {
     expect(Registry.getVisibleEntitiesForArea('kitchen')).toHaveLength(0);
   });
 });
+
+describe('areas_display.hidden filtering for utility entities (#428)', () => {
+  it('filters hidden-area lights and covers while preserving default visibility', () => {
+    const hass = makeHass({
+      areas: [
+        { area_id: 'hidden-area', name: 'Hidden area' },
+        { area_id: 'visible-area', name: 'Visible area' },
+      ],
+      entities: [
+        { entity_id: 'light.hidden', area_id: 'hidden-area' },
+        { entity_id: 'light.visible', area_id: 'visible-area' },
+        { entity_id: 'cover.hidden', area_id: 'hidden-area' },
+        { entity_id: 'cover.visible', area_id: 'visible-area' },
+        { entity_id: 'light.unassigned' },
+      ],
+    });
+
+    Registry.initialize(hass, { areas_display: { hidden: ['hidden-area'] } });
+
+    expect(Registry.getVisibleEntityIdsForDomain('light')).toEqual([
+      'light.hidden',
+      'light.visible',
+      'light.unassigned',
+    ]);
+    expect(Registry.getVisibleEntityIdsForDomain('light', true)).toEqual(['light.visible', 'light.unassigned']);
+    expect(Registry.getVisibleEntityIdsForDomain('cover', true)).toEqual(['cover.visible']);
+  });
+
+  it('resolves an entity area through its device assignment', () => {
+    const hass = makeHass({
+      areas: [{ area_id: 'hidden-area', name: 'Hidden area' }],
+      devices: [{ id: 'device-1', area_id: 'hidden-area' }],
+      entities: [{ entity_id: 'light.device_area', device_id: 'device-1' }],
+    });
+
+    Registry.initialize(hass, { areas_display: { hidden: ['hidden-area'] } });
+
+    expect(Registry.getAreaIdForEntity('light.device_area')).toBe('hidden-area');
+    expect(Registry.isEntityInHiddenArea('light.device_area')).toBe(true);
+    expect(Registry.getVisibleEntityIdsForDomain('light', true)).toEqual([]);
+  });
+});
+


### PR DESCRIPTION
## Ursache

areas_display.hidden wurde bei Licht-/Cover-Gruppierungen und den zugehörigen Summary-Zählern nicht berücksichtigt. Dadurch konnten versteckte Bereiche weiterhin in Utility-Ansichten und Zählern erscheinen.

## Änderung

- Ergänzt einen zentralen, optionalen Bereichsfilter in der Registry.
- Licht- und Cover-Gruppierungen sowie die Licht-/Cover-Summary-Zähler schließen Entitäten aus versteckten Bereichen aus.
- Direkte und über Geräte vererbte Bereichszuordnungen werden berücksichtigt.
- Das bestehende Security-Verhalten bleibt unverändert.

## Tests

- npm test — 243 Tests erfolgreich
- npm run lint — erfolgreich
- npm run format:check — erfolgreich
- npm run build — erfolgreich

Closes #428