### PR TITLE
fix(covers): keep moving covers visible

### DIFF
--- a/src/cards/CoversGroupCard.ts
+++ b/src/cards/CoversGroupCard.ts
@@ -11,6 +11,7 @@ import { localize } from '../utils/localize';
 import { isEntityCurrentlyAvailable } from '../utils/availability-utils';
 import { getVisibleAreasFromHass } from '../utils/name-utils';
 import type { AreasDisplay } from '../types/strategy';
+import { isCoverRelevantForGroup } from '../utils/cover-state-utils';
 
 interface LovelaceCardElement extends HTMLElement {
   hass?: HomeAssistant;
@@ -182,36 +183,7 @@ class Simon42CoversGroupCard extends LitElement {
       if (!state) continue;
 
       const position = (state.attributes as any)?.current_position;
-      const hasPosition = typeof position === 'number';
-      const isMoving = state.state === 'opening' || state.state === 'closing';
-
-      if (groupType === 'partially_open') {
-        // Partially open: position between 0 and 100 (open or currently moving)
-        if (state.state === 'open' || isMoving) {
-          if (hasPosition && position > 0 && position < 100) {
-            relevant.push(id);
-          }
-        }
-      } else if (groupType === 'open') {
-        if (state.state === 'open' || state.state === 'opening') {
-          if (showPartiallyOpen) {
-            // Only fully open (100%) or covers without position attribute
-            if (!hasPosition || position >= 100) {
-              relevant.push(id);
-            }
-          } else {
-            relevant.push(id);
-          }
-        }
-      } else {
-        if (state.state === 'closed') {
-          relevant.push(id);
-        } else if (state.state === 'closing') {
-          // When partially_open is active, closing covers with position > 0 belong to partially_open
-          if (showPartiallyOpen && hasPosition && position > 0) continue;
-          relevant.push(id);
-        }
-      }
+      if (isCoverRelevantForGroup(state.state, position, groupType, showPartiallyOpen)) relevant.push(id);
     }
 
     relevant.sort((a, b) => {
@@ -284,8 +256,15 @@ class Simon42CoversGroupCard extends LitElement {
    */
   private _groupByAreas(covers: string[]): CoversAreaGroup[] {
     if (!this.hass) return [];
-    const dashboardConfig = (this._config.config || {}) as { areas_display?: AreasDisplay; use_default_area_sort?: boolean };
-    const visibleAreas = getVisibleAreasFromHass(this.hass, dashboardConfig.areas_display, dashboardConfig.use_default_area_sort);
+    const dashboardConfig = (this._config.config || {}) as {
+      areas_display?: AreasDisplay;
+      use_default_area_sort?: boolean;
+    };
+    const visibleAreas = getVisibleAreasFromHass(
+      this.hass,
+      dashboardConfig.areas_display,
+      dashboardConfig.use_default_area_sort
+    );
 
     const byArea = new Map<string, string[]>();
     const noArea: string[] = [];
@@ -341,7 +320,7 @@ class Simon42CoversGroupCard extends LitElement {
 
   private _buildHeadingConfig(
     covers: string[],
-    opts: { label?: string; icon?: string; level?: 'main' | 'floor' | 'area'; areaId?: string | null } = {},
+    opts: { label?: string; icon?: string; level?: 'main' | 'floor' | 'area'; areaId?: string | null } = {}
   ): Record<string, unknown> {
     const level = opts.level ?? 'main';
 
@@ -400,12 +379,14 @@ class Simon42CoversGroupCard extends LitElement {
     }
 
     const isOpen = groupType === 'open';
-    const headingLabel = floorLabel || (isOpen
-      ? (this._config.heading_open || localize('covers.open'))
-      : (this._config.heading_closed || localize('covers.closed')));
+    const headingLabel =
+      floorLabel ||
+      (isOpen
+        ? this._config.heading_open || localize('covers.open')
+        : this._config.heading_closed || localize('covers.closed'));
     const defaultIcon = isOpen ? 'mdi:blinds-horizontal' : 'mdi:blinds';
-    const headingIcon = floorIcon
-      || (isOpen ? (this._config.icon_open || defaultIcon) : (this._config.icon_closed || defaultIcon));
+    const headingIcon =
+      floorIcon || (isOpen ? this._config.icon_open || defaultIcon : this._config.icon_closed || defaultIcon);
     return {
       type: 'heading',
       heading: `${headingLabel} (${covers.length})`,
@@ -549,7 +530,7 @@ class Simon42CoversGroupCard extends LitElement {
     slotId: string,
     cardMap: Map<string, LovelaceCardElement>,
     key: string,
-    headingConfig: Record<string, unknown>,
+    headingConfig: Record<string, unknown>
   ): void {
     const hass = this.hass;
     if (!hass) return;
@@ -644,7 +625,7 @@ class Simon42CoversGroupCard extends LitElement {
           `floor-heading-${floorKey}`,
           this._floorHeadingCards,
           floorKey,
-          this._buildHeadingConfig(group.covers, { label: group.floorName, icon: group.floorIcon, level: 'floor' }),
+          this._buildHeadingConfig(group.covers, { label: group.floorName, icon: group.floorIcon, level: 'floor' })
         );
 
         if (groupByAreas) {
@@ -658,7 +639,7 @@ class Simon42CoversGroupCard extends LitElement {
               this._getAreaSlotId('area-heading', floorKey, areaKey),
               this._areaHeadingCards,
               compositeKey,
-              this._buildHeadingConfig(area.covers, { label: area.areaName, level: 'area', areaId: area.areaId }),
+              this._buildHeadingConfig(area.covers, { label: area.areaName, level: 'area', areaId: area.areaId })
             );
             this._reconcileGrid(this._getAreaSlotId('area-grid', floorKey, areaKey), area.covers);
           }
@@ -684,7 +665,7 @@ class Simon42CoversGroupCard extends LitElement {
           this._getAreaSlotId('area-heading', null, areaKey),
           this._areaHeadingCards,
           areaKey,
-          this._buildHeadingConfig(area.covers, { label: area.areaName, level: 'area', areaId: area.areaId }),
+          this._buildHeadingConfig(area.covers, { label: area.areaName, level: 'area', areaId: area.areaId })
         );
         this._reconcileGrid(this._getAreaSlotId('area-grid', null, areaKey), area.covers);
       }
@@ -705,3 +686,4 @@ class Simon42CoversGroupCard extends LitElement {
 }
 
 customElements.define('simon42-covers-group-card', Simon42CoversGroupCard);
+

--- a/src/utils/cover-state-utils.ts
+++ b/src/utils/cover-state-utils.ts
@@ -1,0 +1,40 @@
+// ====================================================================
+// COVER STATE GROUPING
+// ====================================================================
+// Keeps moving covers in one visible group at the 0%/100% transition
+// boundaries so their stop control remains reachable.
+// ====================================================================
+
+export type CoverGroupType = 'open' | 'closed' | 'partially_open';
+
+export function isCoverRelevantForGroup(
+  state: string,
+  position: unknown,
+  groupType: CoverGroupType,
+  showPartiallyOpen: boolean
+): boolean {
+  const hasPosition = typeof position === 'number';
+  const isMoving = state === 'opening' || state === 'closing';
+
+  if (groupType === 'partially_open') {
+    if (state !== 'open' && !isMoving) return false;
+    if (!hasPosition) return false;
+
+    const isBetweenEndpoints = position > 0 && position < 100;
+    const isOpeningAtClosedEndpoint = state === 'opening' && position === 0;
+    const isClosingAtOpenEndpoint = state === 'closing' && position === 100;
+    return isBetweenEndpoints || isOpeningAtClosedEndpoint || isClosingAtOpenEndpoint;
+  }
+
+  if (groupType === 'open') {
+    if (state !== 'open' && state !== 'opening') return false;
+    if (!showPartiallyOpen) return true;
+    return !hasPosition || position >= 100;
+  }
+
+  if (state === 'closed') return true;
+  if (state !== 'closing') return false;
+  if (showPartiallyOpen && hasPosition && position > 0) return false;
+  return true;
+}
+

--- a/tests/utils/cover-state-utils.test.ts
+++ b/tests/utils/cover-state-utils.test.ts
@@ -1,0 +1,41 @@
+// ============================================================================
+// Tests — Cover grouping while moving (#435)
+// ============================================================================
+
+import { describe, expect, it } from 'vitest';
+
+import { isCoverRelevantForGroup } from '../../src/utils/cover-state-utils';
+
+describe('isCoverRelevantForGroup', () => {
+  it('keeps an opening cover visible at the 0% endpoint in partial mode', () => {
+    expect(isCoverRelevantForGroup('opening', 0, 'partially_open', true)).toBe(true);
+    expect(isCoverRelevantForGroup('opening', 0, 'open', true)).toBe(false);
+  });
+
+  it('keeps a closing cover visible at the 100% endpoint in partial mode', () => {
+    expect(isCoverRelevantForGroup('closing', 100, 'partially_open', true)).toBe(true);
+    expect(isCoverRelevantForGroup('closing', 100, 'closed', true)).toBe(false);
+  });
+
+  it('keeps moving covers in the partial group between endpoints', () => {
+    expect(isCoverRelevantForGroup('opening', 50, 'partially_open', true)).toBe(true);
+    expect(isCoverRelevantForGroup('closing', 50, 'partially_open', true)).toBe(true);
+    expect(isCoverRelevantForGroup('opening', 50, 'open', true)).toBe(false);
+    expect(isCoverRelevantForGroup('closing', 50, 'closed', true)).toBe(false);
+  });
+
+  it('preserves normal open and closed grouping', () => {
+    expect(isCoverRelevantForGroup('open', 100, 'open', true)).toBe(true);
+    expect(isCoverRelevantForGroup('closed', 0, 'closed', true)).toBe(true);
+    expect(isCoverRelevantForGroup('open', 100, 'partially_open', true)).toBe(false);
+    expect(isCoverRelevantForGroup('closed', 0, 'partially_open', true)).toBe(false);
+  });
+
+  it('keeps the original moving behavior when partial mode is disabled', () => {
+    expect(isCoverRelevantForGroup('opening', 0, 'open', false)).toBe(true);
+    expect(isCoverRelevantForGroup('closing', 100, 'closed', false)).toBe(true);
+    expect(isCoverRelevantForGroup('opening', 50, 'open', false)).toBe(true);
+    expect(isCoverRelevantForGroup('closing', 50, 'closed', false)).toBe(true);
+  });
+});
+


### PR DESCRIPTION
## Ursache

Bewegende Rollläden konnten bei aktivierter Teilöffnen-Anzeige an den Zustandsgrenzen aus allen Cover-Gruppen verschwinden: beim Öffnen mit Position 0 und beim Schließen mit Position 100. Dadurch war die Stop-Steuerung nicht erreichbar.

## Änderung

- Cover-Gruppierungslogik in einen testbaren Helper ausgelagert.
- Öffnende Cover bei 0 % und schließende Cover bei 100 % bleiben während der Fahrt sichtbar.
- Zwischenpositionen bleiben in der Teilöffnen-Gruppe.
- Das bisherige Verhalten ohne Teilöffnen-Anzeige bleibt unverändert.
- Keine Änderungen am Security-Verhalten oder an YAML-Konfigurationen.

## Tests

- npm test — 246 Tests erfolgreich
- npm run lint — erfolgreich
- npm run format:check — erfolgreich
- npm run build — erfolgreich

Closes #435