### PR TITLE
fix(rooms): show generic opening contacts

### DIFF
--- a/src/editor/panels/AreasPanel.ts
+++ b/src/editor/panels/AreasPanel.ts
@@ -27,7 +27,13 @@ import type {
 } from '../../types/strategy';
 import type { AreaRegistryEntry, EntityRegistryEntry } from '../../types/registries';
 import { localize } from '../../utils/localize';
-import { isBadgeCandidate, isDefaultShowName, isEnergyBlockSensor, resolveShowName } from '../../utils/badge-utils';
+import {
+  isBadgeCandidate,
+  isDefaultShowName,
+  isEnergyBlockSensor,
+  isWindowContactDeviceClass,
+  resolveShowName,
+} from '../../utils/badge-utils';
 import { findUpsEntityGroups } from '../../views/RoomViewStrategy';
 import { stateFor } from '../entity-options';
 import type { StrategyEditorHost } from '../editor-host';
@@ -60,7 +66,7 @@ export function renderAreasSection(host: StrategyEditorHost): TemplateResult {
   const showScriptsInRooms = host._config.show_scripts_in_rooms === true;
   const showUpsInRooms = host._config.show_ups_in_rooms === true;
   const showEnergyInRooms = host._config.show_energy_in_rooms === true;
-  // Window / door contact badges default to visible — read as opt-out (!== false).
+  // Window / opening / door contact badges default to visible — read as opt-out (!== false).
   const showWindowContactsInRooms = host._config.show_window_contacts_in_rooms !== false;
   const showDoorContactsInRooms = host._config.show_door_contacts_in_rooms !== false;
   const showCamerasInRooms = host._config.show_cameras_in_rooms !== false;
@@ -1376,7 +1382,7 @@ function getAreaBadgeCandidates(areaId: string, hass: HomeAssistant, config: Sim
     // Globally disabled contact types don't render as badges — don't offer
     // them as candidates either (they stay pickable as additional badges,
     // which is the deliberate per-room override).
-    if (domain === 'binary_sensor' && dc === 'window' && config.show_window_contacts_in_rooms === false) continue;
+    if (domain === 'binary_sensor' && isWindowContactDeviceClass(dc) && config.show_window_contacts_in_rooms === false) continue;
     if (domain === 'binary_sensor' && dc === 'door' && config.show_door_contacts_in_rooms === false) continue;
 
     if (domain === 'sensor' && (dc === 'battery' || entity.entity_id.includes('battery'))) {

--- a/src/utils/badge-utils.ts
+++ b/src/utils/badge-utils.ts
@@ -24,6 +24,7 @@ export const BADGE_COLOR_MAP: Record<string, string> = {
   presence: 'cyan',
   moisture: 'blue',
   window: 'teal',
+  opening: 'teal',
   door: 'teal',
   smoke: 'red',
   gas: 'red',
@@ -33,6 +34,11 @@ export const BADGE_COLOR_MAP: Record<string, string> = {
   power: 'orange',
   energy: 'orange',
 };
+
+/** Whether a binary sensor represents a window-style open/closed contact. */
+export function isWindowContactDeviceClass(deviceClass: string | undefined): boolean {
+  return deviceClass === 'window' || deviceClass === 'opening';
+}
 
 // -- Badge color for a specific entity --------------------------------
 
@@ -110,7 +116,7 @@ export function isBadgeCandidate(
       deviceClass === 'motion' ||
       deviceClass === 'occupancy' ||
       deviceClass === 'presence' ||
-      deviceClass === 'window' ||
+      isWindowContactDeviceClass(deviceClass) ||
       deviceClass === 'door' ||
       deviceClass === 'smoke' ||
       deviceClass === 'gas' ||
@@ -197,7 +203,7 @@ export function selectBadgeEntitiesOfType(entities: string[], hiddenBadges: Read
 
 /** Whether a badge with this device_class shows its entity name by default */
 export function isDefaultShowName(deviceClass: string | undefined): boolean {
-  return deviceClass === 'window' || deviceClass === 'door';
+  return isWindowContactDeviceClass(deviceClass) || deviceClass === 'door';
 }
 
 // -- Show name resolution ---------------------------------------------

--- a/src/views/RoomViewStrategy.ts
+++ b/src/views/RoomViewStrategy.ts
@@ -22,6 +22,7 @@ import {
   applyBadgeGroupOptions,
   isDefaultShowName,
   isEnergyBlockSensor,
+  isWindowContactDeviceClass,
   resolveShowName,
   selectBadgeEntitiesOfType,
   type BadgeCandidate,
@@ -439,7 +440,7 @@ class Simon42ViewRoomStrategy extends HTMLElement {
           sensorEntities.occupancy.push(entityId);
           continue;
         }
-        if (deviceClass === 'window') {
+        if (isWindowContactDeviceClass(deviceClass)) {
           sensorEntities.window.push(entityId);
           continue;
         }

--- a/tests/utils/badge-utils.test.ts
+++ b/tests/utils/badge-utils.test.ts
@@ -11,8 +11,11 @@ import { describe, it, expect } from 'vitest';
 
 import {
   applyBadgeGroupOptions,
+  getColorForEntity,
   isBadgeCandidate,
+  isDefaultShowName,
   isEnergyBlockSensor,
+  isWindowContactDeviceClass,
   selectBadgeEntitiesOfType,
   type BadgeCandidate,
 } from '../../src/utils/badge-utils';
@@ -111,6 +114,25 @@ describe('isBadgeCandidate — energy-block sensors excluded (#396)', () => {
     expect(isBadgeCandidate('sensor', 'illuminance', 'lx', 'sensor.kitchen_light_level')).toBe(true);
     expect(isBadgeCandidate('sensor', 'carbon_dioxide', 'ppm', 'sensor.kitchen_air')).toBe(true);
     expect(isBadgeCandidate('binary_sensor', 'gas', undefined, 'binary_sensor.kitchen_gas_alarm')).toBe(true);
+  });
+});
+
+describe('window contact device classes (#437)', () => {
+  it('treats generic opening sensors as window contact badges', () => {
+    expect(isWindowContactDeviceClass('window')).toBe(true);
+    expect(isWindowContactDeviceClass('opening')).toBe(true);
+    expect(isWindowContactDeviceClass('door')).toBe(false);
+    expect(isBadgeCandidate('binary_sensor', 'opening', undefined, 'binary_sensor.kitchen_window')).toBe(true);
+    expect(isDefaultShowName('opening')).toBe(true);
+  });
+
+  it('uses the window contact badge color for opening sensors', () => {
+    const hass = makeHass({
+      entities: [
+        { entity_id: 'binary_sensor.kitchen_window', attributes: { device_class: 'opening' } },
+      ],
+    });
+    expect(getColorForEntity('binary_sensor.kitchen_window', hass)).toBe('teal');
   });
 });
 


### PR DESCRIPTION
## Ursache

Die Security-Ansicht erkannte `binary_sensor` mit `device_class: opening`, die Raumansicht und der Editor-Picker jedoch nur `window` und `door`. Dadurch fehlten generische Öffnungssensoren in Raumansichten.

## Änderung

- Gemeinsame Erkennung für Fensterkontakte (`window` und `opening`) ergänzt.
- Raumansicht und Editor berücksichtigen `device_class: opening`.
- Öffnungssensoren erhalten die Fensterkontakt-Farbe und die Standard-Namensanzeige.
- Der bestehende Toggle `show_window_contacts_in_rooms` gilt auch für `opening`.
- Keine Änderungen an Konfigurationsschema, Versionierung oder `dist/`.

## Tests

- `npx tsc --noEmit`
- `npm run lint`
- `npm test` — 243 Tests erfolgreich
- `node scripts/lint-translations.mjs`
- `npm run build`
- `git diff --check`

Der lokale globale Prettier-Check meldet bereits vorhandene Windows-Line-Ending-Abweichungen in 68 Upstream-Dateien; keine dieser Dateien wurde geändert.

Closes #437